### PR TITLE
Metadata Cohort Display Filter Updates

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"

--- a/client/platform/web-girder/api/divemetadata.service.ts
+++ b/client/platform/web-girder/api/divemetadata.service.ts
@@ -55,7 +55,7 @@ function getMetadataFilterValues(folderId: string, keys?: string[]) {
   });
 }
 
-function filterDiveMetadata(folderId: string, filters: DIVEMetadataFilter, offset = 0, limit = 50, sort = 'filename', sortdir = -1) {
+function filterDiveMetadata(folderId: string, filters: DIVEMetadataFilter, offset = 0, limit = 50, sort = 'filename', sortdir = 1) {
   return girderRest.get<DIVEMetadataResults>(`dive_metadata/${folderId}/filter`, {
     params: {
       filters, offset, limit, sort, sortdir,

--- a/client/platform/web-girder/views/DIVEMetadataClone.vue
+++ b/client/platform/web-girder/views/DIVEMetadataClone.vue
@@ -82,7 +82,6 @@ export default defineComponent({
       >
         <GirderFileManager
           new-folder-enabled
-          root-location-disabled
           no-access-control
           :location="location"
           @update:location="setLocation"

--- a/client/platform/web-girder/views/DIVEMetadataFilter.vue
+++ b/client/platform/web-girder/views/DIVEMetadataFilter.vue
@@ -244,10 +244,10 @@ export default defineComponent({
           hide-details
         />
         <v-icon v-if="sortDir === 1" @click="sortDir = -1">
-          mdi-sort-descending
+          mdi-sort-ascending
         </v-icon>
         <v-icon v-else-if="sortDir === -1" @click="sortDir = 1">
-          mdi-sort-ascending
+          mdi-sort-descending
         </v-icon>
       </v-row>
       <v-row

--- a/client/platform/web-girder/views/DIVEMetadataFilterItem.vue
+++ b/client/platform/web-girder/views/DIVEMetadataFilterItem.vue
@@ -31,6 +31,12 @@ export default defineComponent({
     const categoryLimit = ref(20);
     const enabled = ref(props.defaultEnabled); // numerical enabled filter
     watch([value, enabled], () => {
+      if (enabled.value) {
+        if (value.value === undefined && props.filterItem.category === 'numerical' && props.filterItem.range) {
+          value.value = [props.filterItem.range.min, props.filterItem.range.max];
+        }
+      }
+
       const update = {
         value: value.value,
         category: props.filterItem.category,
@@ -45,6 +51,9 @@ export default defineComponent({
       emit('update-value', update);
     });
     if (enabled.value) {
+      if (value.value === undefined && props.filterItem.category === 'numerical' && props.filterItem.range) {
+        value.value = [props.filterItem.range.min, props.filterItem.range.max];
+      }
       const update = {
         value: value.value,
         category: props.filterItem.category,

--- a/client/platform/web-girder/views/DIVEMetadataSearch.vue
+++ b/client/platform/web-girder/views/DIVEMetadataSearch.vue
@@ -63,7 +63,7 @@ export default defineComponent({
 
     const updateURLParams = () => {
       if ((filters.value.metadataFilters && Object.keys(filters.value.metadataFilters).length) || filters.value.search) {
-        router.replace({ path: props.id, params: { id: props.id }, query: { filter: JSON.stringify(filters.value) } });
+        window.location.href = window.location.href.replace(/metadata\/.*/, `metadata/${props.id}?filter=${(JSON.stringify(filters.value))}`);
       } else {
         window.location.href = window.location.href.replace(/filter=.*/, '');
       }
@@ -74,21 +74,33 @@ export default defineComponent({
       getData();
     });
 
-    const updateFilter = async (filter?: DIVEMetadataFilter) => {
+    const storedSortVal = ref('filename');
+    const storedSortDir = ref(1);
+
+    const updateFilter = async ({ filter, sortVal, sortDir } : { filter?:DIVEMetadataFilter, sortVal?: string, sortDir?: number}) => {
       if (filter) {
         filters.value = filter;
         currentPage.value = 0;
         currentFilter.value = filter;
       }
-      const sort = 'filename';
+      if (sortVal) {
+        storedSortVal.value = sortVal;
+      }
+      if (sortDir) {
+        storedSortDir.value = sortDir;
+      }
       updateURLParams();
-      const { data } = await filterDiveMetadata(props.id, { ...filters.value }, currentPage.value * 50, 50, sort);
+      let updatedSortVal = sortVal;
+      if (updatedSortVal !== 'filename') {
+        updatedSortVal = `metadata.${updatedSortVal}`;
+      }
+      const { data } = await filterDiveMetadata(props.id, { ...filters.value }, currentPage.value * 50, 50, updatedSortVal, sortDir);
       processFilteredMetadataResults(data);
     };
 
     const changePage = async (page: number) => {
       currentPage.value = page;
-      await updateFilter();
+      await updateFilter({ filter: currentFilter.value, sortVal: storedSortVal.value, sortDir: storedSortDir.value });
     };
 
     const advanced = computed(() => {

--- a/client/platform/web-girder/views/DIVEMetadataSearch.vue
+++ b/client/platform/web-girder/views/DIVEMetadataSearch.vue
@@ -7,7 +7,6 @@ import {
   DIVEMetadataResults, DIVEMetadataFilter, filterDiveMetadata, MetadataResultItem, FilterDisplayConfig,
 } from 'platform/web-girder/api/divemetadata.service';
 import { getFolder } from 'platform/web-girder/api/girder.service';
-import { useRouter } from 'vue-router/composables';
 import DIVEMetadataFilterVue from './DIVEMetadataFilter.vue';
 import DIVEMetadataCloneVue from './DIVEMetadataClone.vue';
 
@@ -29,7 +28,6 @@ export default defineComponent({
   },
   setup(props) {
     const folderList: Ref<MetadataResultItem[]> = ref([]);
-    const router = useRouter();
     const displayConfig: Ref<FilterDisplayConfig> = ref({ display: [], hide: [] });
     const totalPages = ref(0);
     const currentPage = ref(0);


### PR DESCRIPTION
resolves #122 - Now it will look in children directories instead of looking in the current directory for matching folders
resolves #123 - Added a unique item to the keys filter to determine how many items are unique.  Also made it to so you can customize on import the limit for categorical searches.
resolves #125 - When closing the advanced filters those filters are now disabled instead of saving them
resolves #126 - You can no add your new cloned folder to any location, it just needs to be in a folder.
resolves #127 - Adds in a sorting option based on the keys in the system