### PR TITLE
fix metadata advanced, fix swimlane tooltip

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.10.9",
+  "version": "1.10.10",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"

--- a/client/platform/web-girder/views/DIVEMetadataSearch.vue
+++ b/client/platform/web-girder/views/DIVEMetadataSearch.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import {
-  computed,
   defineComponent, onMounted, ref, Ref, PropType,
 } from 'vue';
 import {
@@ -101,19 +100,16 @@ export default defineComponent({
       await updateFilter({ filter: currentFilter.value, sortVal: storedSortVal.value, sortDir: storedSortDir.value });
     };
 
-    const advanced = computed(() => {
+    const getAdvanced = (item: MetadataResultItem) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const advancedList: Record<string, any> = {};
-      for (let i = 0; i < folderList.value.length; i += 1) {
-        const item = folderList.value[i];
-        Object.entries(item.metadata).forEach(([key, value]) => {
-          if (!displayConfig.value.hide.includes(key)) {
-            advancedList[key] = value;
-          }
-        });
-      }
+      Object.entries(item.metadata).forEach(([key, value]) => {
+        if (!displayConfig.value.hide.includes(key)) {
+          advancedList[key] = value;
+        }
+      });
       return advancedList;
-    });
+    };
     const openClone = ref(false);
     return {
       totalPages,
@@ -125,7 +121,7 @@ export default defineComponent({
       updateFilter,
       folderList,
       displayConfig,
-      advanced,
+      getAdvanced,
       filters,
       //Cloning
       openClone,
@@ -211,7 +207,7 @@ export default defineComponent({
           <v-expansion-panel class="border">
             <v-expansion-panel-header>Advanced</v-expansion-panel-header>
             <v-expansion-panel-content>
-              <v-row v-for="(data, dataKey) in advanced" :key="dataKey" class="border" dense>
+              <v-row v-for="(data, dataKey) in getAdvanced(item)" :key="dataKey" class="border" dense>
                 <v-col cols="2" class="border">
                   <b>{{ dataKey }}:</b>
                 </v-col>

--- a/client/src/components/controls/AttributeSwimlaneGraph.vue
+++ b/client/src/components/controls/AttributeSwimlaneGraph.vue
@@ -61,7 +61,7 @@ export default Vue.extend({
         return {
           style: {
             left: `${this.tooltip.left + 15}px`,
-            top: `${this.tooltip.top + 15}px`,
+            top: `${this.tooltip.top + 0}px`,
           },
           ...this.tooltip,
         };
@@ -236,18 +236,20 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div
-    class="event-chart"
-    :style="`height: ${clientHeight - 10}px;`"
-    @mousewheel.prevent
-    @scroll="recordScroll"
-  >
-    <canvas
-      ref="canvas"
-      @mousemove="mousemove"
-      @mouseout="mouseout"
-      @mousedown="mousedown"
-    />
+  <div style="position: relative;">
+    <div
+      class="event-chart"
+      :style="`height: ${clientHeight - 10}px;`"
+      @mousewheel.prevent
+      @scroll="recordScroll"
+    >
+      <canvas
+        ref="canvas"
+        @mousemove="mousemove"
+        @mouseout="mouseout"
+        @mousedown="mousedown"
+      />
+    </div>
     <div
       v-if="tooltipComputed"
       class="tooltip"
@@ -259,13 +261,19 @@ export default Vue.extend({
         align="center"
         justify="center"
       >
-        <span> {{ tooltipComputed.name }}</span>
+        <v-col>
+          <span> {{ tooltipComputed.name }}</span>
+        </v-col>
         <span
           class="type-color-box"
           :style="{ backgroundColor: tooltipComputed.contentColor }"
         />
-        :
-        <span> {{ tooltipComputed.subDisplay }}</span>
+        <v-col>
+          <span>:</span>
+        </v-col>
+        <v-col>
+          <span> {{ tooltipComputed.subDisplay }}</span>
+        </v-col>
         <span
           class="type-color-box"
           :style="{ backgroundColor: tooltipComputed.subColor }"
@@ -280,22 +288,23 @@ export default Vue.extend({
   position: relative;
   height: calc(100% - 10px);
   margin: 5px 0;
-  overflow-y: auto;
+  overflow-y: visible;
   overflow-x: hidden;
 
-  .tooltip {
+}
+.tooltip {
     position: absolute;
     background: black;
     border: 1px solid white;
     padding: 0px 5px;
     font-size: 20px;
     font-weight: bold;
-    z-index: 2;
+    z-index: 9999;
   }
-}
+
 .type-color-box {
   margin-right: 5px;
-  margin-top:5px;
+  margin-top: 5px;
   min-width: 10px;
   max-width: 10px;
   min-height: 10px;

--- a/client/src/components/controls/EventChart.vue
+++ b/client/src/components/controls/EventChart.vue
@@ -60,7 +60,7 @@ export default Vue.extend({
         return {
           style: {
             left: `${this.tooltip.left + 15}px`,
-            top: `${this.tooltip.top + 15}px`,
+            top: `${this.tooltip.top + 0}px`,
           },
           ...this.tooltip,
         };
@@ -311,7 +311,7 @@ export default Vue.extend({
     border: 1px solid white;
     padding: 0px 5px;
     font-size: 14px;
-    z-index: 2;
+    z-index: 9999;
   }
 }
 </style>

--- a/client/src/components/controls/LineChart.vue
+++ b/client/src/components/controls/LineChart.vue
@@ -196,7 +196,8 @@ export default Vue.extend({
           tooltipTimeoutHandle = setTimeout(() => {
             tooltip
               .style('left', `${_x + 2}px`)
-              .style('top', `${_y - 25}px`)
+              .style('top', `${_y + this.chartTop}px`)
+              .style('position', 'asbsolute')
               .text(d.name)
               .style('display', 'block');
             d3.select(this).style('stroke', 'cyan').style('stroke-width', 3);


### PR DESCRIPTION
resolves #142 
resolves #143

- Fixes advanced metadata fields not rendering with the associated metadata
- modifies the tooltip display for the timeline/swimlane graphs to be over the other items.