### PR TITLE
non match issue for regex VideoType

### DIFF
--- a/server/dive_server/web_client/utils/utils.js
+++ b/server/dive_server/web_client/utils/utils.js
@@ -69,7 +69,7 @@ function convertToDIVEHandler(e) {
 function  isVideoType(name) {
     const extensions = name.match(fileSuffixRegex);
     let extension = '';
-    if (extensions.length){
+    if (extensions && extensions.length){
         extension = extensions[0];
     }
     return fileVideoTypes.includes(extension)


### PR DESCRIPTION
#158 

Made a mistake in not accounting for null values when matching the regex to determine if the file extension is of a videoType.
Typically don't have dev tools open when in the Girder interface.

Still a temporary solution of utilizing the file extension until a better way is developed to figure out if data types are videos.