### PR TITLE
support clone video overlays, transfer swimlane configurations

### DIFF
--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -160,7 +160,6 @@ class DatasetResource(Resource):
             if overlayCloneFolder is not None:
                 overlayFolder = overlayCloneFolder
 
-
         if item["folderId"] == root["_id"] or item["folderId"] == overlayFolder["_id"]:
             files = list(Item().childFiles(item))
             if len(files) != 1:

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -150,6 +150,16 @@ class DatasetResource(Resource):
                 f'meta.{constants.OverlayVideoFolderMarker}': {'$in': TRUTHY_META_VALUES},
             }
         )
+        if root['_id'] != folder['_id']:  # Must be a clone check for overlay folders in clone
+            overlayCloneFolder = Folder().findOne(
+                {
+                    'parentId': folder['_id'],
+                    f'meta.{constants.OverlayVideoFolderMarker}': {'$in': TRUTHY_META_VALUES},
+                }
+            )
+            if overlayCloneFolder is not None:
+                overlayFolder = overlayCloneFolder
+
 
         if item["folderId"] == root["_id"] or item["folderId"] == overlayFolder["_id"]:
             files = list(Item().childFiles(item))


### PR DESCRIPTION
resolves #147 - The transfer configuration wasn't transferring 'swimlanes' configurations.  It's updated now.
resolves #159 - clonedDatasets can have their own videoOverlays now