### PR TITLE
UINotification Actions and Shortcuts

### DIFF
--- a/client/dive-common/components/Attributes/AttributeShortcutToggle.vue
+++ b/client/dive-common/components/Attributes/AttributeShortcutToggle.vue
@@ -74,6 +74,7 @@ export default defineComponent({
           if (id && config.value) {
             configMan.saveConfiguration(id, config.value);
           }
+        }
       }
     };
     const actionShortcuts = computed(() => {
@@ -102,8 +103,8 @@ export default defineComponent({
         if (diveAction.shortcut && diveAction.applyConfig) {
           addUpdateAction(diveAction);
         }
-      })
-    })
+      });
+    });
     const shortcutList = computed(() => {
       const dataList: {
         shortcut: string;

--- a/client/dive-common/components/Attributes/AttributeShortcutToggle.vue
+++ b/client/dive-common/components/Attributes/AttributeShortcutToggle.vue
@@ -43,7 +43,7 @@ export default defineComponent({
       if (diveActionShortcut.shortcut) {
         bind = diveActionShortcut.shortcut.key.toLocaleLowerCase();
         if (diveActionShortcut.shortcut.modifiers) {
-          bind = `${bind}+${diveActionShortcut.shortcut.modifiers?.join('+')}`;
+          bind = `${diveActionShortcut.shortcut.modifiers?.join('+')}+${bind}`;
         }
       }
       return bind;
@@ -98,13 +98,14 @@ export default defineComponent({
       return dataList;
     });
 
-    watch(diveActionShortcuts, () => {
+    watch(diveActionShortcuts.value, () => {
       diveActionShortcuts.value.forEach((diveAction) => {
         if (diveAction.shortcut && diveAction.applyConfig) {
           addUpdateAction(diveAction);
         }
       });
     });
+
     const shortcutList = computed(() => {
       const dataList: {
         shortcut: string;
@@ -195,7 +196,9 @@ export default defineComponent({
       // UINotificaton Shortcuts, These take precendence over Attribute/System Actions
       diveActionShortcuts.value.forEach((diveActionShortcut) => {
         const bind = getDiveActionShortcutString(diveActionShortcut);
-        actions.push({ bind, handler: () => runUIAction(bind), disabled: props.hotkeysDisabled });
+        if (!diveActionShortcut.applyConfig) {
+          actions.push({ bind, handler: () => runUIAction(bind), disabled: props.hotkeysDisabled });
+        }
       });
 
       // System Actions
@@ -337,12 +340,12 @@ export default defineComponent({
               <span>Description</span>
             </v-col>
           </v-row>
-          <v-row dense>
+          <v-row dense class="pl-2">
             <b>Action Shortcuts</b>
           </v-row>
           <v-row
             v-for="shortcut in actionShortcuts"
-            :key="`${shortcut.shortcut}`"
+            :key="`${shortcut.shortcut}_Action`"
             class="helpContextRow ma-0 align-cente py-2"
             style="border: 1px solid gray;"
             dense
@@ -360,12 +363,12 @@ export default defineComponent({
               <v-chip>{{ shortcut.description }}</v-chip>
             </v-col>
           </v-row>
-          <v-row v-if="diveActionShortcuts.length" dense>
+          <v-row v-if="diveActionShortcuts.length" dense class="pl-2">
             <b>UI Notification Shortcuts</b>
           </v-row>
           <v-row
             v-for="shortcut in diveActionShortcuts"
-            :key="`${getDiveActionShortcutString(shortcut)}`"
+            :key="`${getDiveActionShortcutString(shortcut)}_DIVEAction`"
             class="helpContextRow ma-0 align-cente py-2"
             style="border: 1px solid gray;"
             dense
@@ -383,7 +386,7 @@ export default defineComponent({
               <v-chip>{{ shortcut.description }}</v-chip>
             </v-col>
           </v-row>
-          <v-row v-if="shortcutList.length" dense>
+          <v-row v-if="shortcutList.length" dense class="pl-2">
             <b>Attribute Shortcuts</b>
           </v-row>
           <v-row

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -56,7 +56,7 @@ import UseTimelineFilters from 'vue-media-annotator/use/useTimelineFilters';
 import { checkAttributes } from 'dive-common/use/useActions';
 import SlicerTaskRunnerVue from 'platform/web-girder/views/SlicerTaskRunner.vue';
 import useURLParameters from 'vue-media-annotator/use/useURLParameters';
-import initializeUINotificationService from 'platform/web-girder/UIControls';
+import useUINotifications from 'platform/web-girder/UIControls';
 import { getLatestRevision } from 'platform/web-girder/api/annotation.service';
 import { OverlayPreferences } from 'vue-media-annotator/types';
 import AttributeShortcutToggle from './Attributes/AttributeShortcutToggle.vue';
@@ -830,7 +830,7 @@ export default defineComponent({
       discardChanges();
       await loadData();
     };
-    initializeUINotificationService({
+    useUINotifications({
       prompt, handler, aggregateController, reloadAnnotations, datasetId,
     });
 

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -830,7 +830,7 @@ export default defineComponent({
       discardChanges();
       await loadData();
     };
-    useUINotifications({
+    const uiNotification = useUINotifications({
       prompt, handler, aggregateController, reloadAnnotations, datasetId,
     });
 
@@ -907,6 +907,7 @@ export default defineComponent({
         annotatorPreferences: toRef(clientSettings, 'annotatorPreferences'),
         attributes,
         configurationManager,
+        uiNotification,
         cameraStore,
         datasetId,
         editingMode,

--- a/client/dive-common/use/useActions.ts
+++ b/client/dive-common/use/useActions.ts
@@ -34,7 +34,7 @@ export interface TrackSelectAction {
 
 export type ActionTypes = 'GoToFrame' | 'SelectTrack' | 'Wait' | 'Popup';
 
-interface GoToFrameAction{
+export interface GoToFrameAction{
     track?: TrackSelectAction; // Go to first frame of track that matches conditions
     frame?: number; // Jump to X frame
     type: 'GoToFrame';
@@ -51,6 +51,17 @@ export interface DIVEActionShortcut {
     };
     description?: string;
     actions: DIVEAction[];
+}
+
+// Either immediately executed action or a keyboard shortcut
+export interface UIDIVEAction {
+  shortcut?: {
+    key: string;
+    modifiers?: string[];
+  }
+  description?: string;
+  applyConfig?: boolean; //Add to the system configuration the shortcut/action
+  actions: DIVEAction[];
 }
 
 const checkAttributes = (attributeMatch: Record<string, AttributeMatch>, attributes: StringKeyObject) => {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.10.14",
+  "version": "1.10.15",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"

--- a/client/platform/web-girder/UIControls.ts
+++ b/client/platform/web-girder/UIControls.ts
@@ -37,6 +37,9 @@ const getActionText = (diveAction: UIDIVEAction) => {
         textShortcut = `${textShortcut}+${diveAction.shortcut.modifiers.join('+')}`;
       }
       text.push(`- Add shortcut Key: ${textShortcut} with Action(s)`);
+      if (diveAction.applyConfig) {
+        text.push('- This shortcut will be added to the configuration');
+      }
     }
     for (let i = 0; i < diveAction.actions.length; i += 1) {
       const { action } = diveAction.actions[i];

--- a/client/platform/web-girder/UIControls.ts
+++ b/client/platform/web-girder/UIControls.ts
@@ -99,7 +99,7 @@ const getDiveActionShortcutString = (diveActionShortcut: UIDIVEAction) => {
   if (diveActionShortcut.shortcut) {
     bind = diveActionShortcut.shortcut.key.toLocaleLowerCase();
     if (diveActionShortcut.shortcut.modifiers) {
-      bind = `${bind}+${diveActionShortcut.shortcut.modifiers?.join('+')}`;
+      bind = `${diveActionShortcut.shortcut.modifiers?.join('+')}+${bind}`;
     }
   }
   return bind;

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -4,6 +4,7 @@ import {
 } from 'vue';
 
 import { DIVEAction } from 'dive-common/use/useActions';
+import { UseUINotificationType } from 'platform/web-girder/UIControls';
 import type { AnnotatorPreferences as AnnotatorPrefsIface } from './types';
 import StyleManager from './StyleManager';
 import type { EditAnnotationTypes } from './layers/EditAnnotationLayer';
@@ -124,6 +125,8 @@ type ImageEnhancementsType = Readonly<Ref<ImageEnhancements>>;
 const CameraStoreSymbol = Symbol('cameraStore');
 
 const ConfigurationManagerSymbol = Symbol('configurationManager');
+
+const UINotificationSymbol = Symbol('uiNotification');
 
 const TrackStyleManagerSymbol = Symbol('trackTypeStyling');
 const GroupStyleManagerSymbol = Symbol('groupTypeStyling');
@@ -261,6 +264,7 @@ export interface State {
   attributes: AttributesType;
   cameraStore: CameraStore;
   configurationManager: ConfigurationManager;
+  uiNotification: UseUINotificationType;
   datasetId: DatasetIdType;
   editingMode: EditingModeType;
   groupFilters: GroupFilterControls;
@@ -319,6 +323,7 @@ function dummyState(): State {
     attributes: ref([]),
     cameraStore,
     configurationManager,
+    uiNotification: { diveActionShortcuts: ref([]) },
     datasetId: ref(''),
     editingMode: ref(false),
     multiSelectList: ref([]),
@@ -360,6 +365,7 @@ function provideAnnotator(state: State, handler: Handler, attributesFilters: Att
   provide(AttributesSymbol, state.attributes);
   provide(CameraStoreSymbol, state.cameraStore);
   provide(ConfigurationManagerSymbol, state.configurationManager);
+  provide(UINotificationSymbol, state.uiNotification);
   provide(DatasetIdSymbol, state.datasetId);
   provide(EditingModeSymbol, state.editingMode);
   provide(GroupFilterControlsSymbol, state.groupFilters);
@@ -417,6 +423,10 @@ function useCameraStore() {
 }
 function useConfiguration() {
   return use<ConfigurationManager>(ConfigurationManagerSymbol);
+}
+
+function useUINotifications() {
+  return use<UseUINotificationType>(UINotificationSymbol);
 }
 
 function useDatasetId() {
@@ -506,6 +516,7 @@ export {
   useAttributes,
   useCameraStore,
   useConfiguration,
+  useUINotifications,
   useDatasetId,
   useEditingMode,
   useHandler,

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
 
   girder:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
 
   traefik:

--- a/docs/UI-Notifications.md
+++ b/docs/UI-Notifications.md
@@ -127,6 +127,7 @@ export interface UINotification {
 ```
 
 The UIDIVEAction allows for executing actions or for creating shortcuts.
+A More detailed listing of this is available at: [UI-Actions](UI-Actions.md )
 
 
 ```

--- a/docs/UI-Notifications.md
+++ b/docs/UI-Notifications.md
@@ -27,4 +27,116 @@ The JSON format is relatively simple but may be updated in the future to have ad
 }
 ```
 
+### Adding Actions to UI Notifications
 
+The below example utilizes the UI-Actions to select a track that meets seom requirements.
+You can specify a list of `diveActions` that can be executed sequentially
+The below action will select the next track that is of type `mouse` and has a detection attribute named `mouseState` that is `=` to `scratching`
+the UI-Actions pages has more information about the existing actions and their capabilities and configuration.
+
+```
+{
+    "text": "Testing the Actions Listing",
+    "diveActions": [
+        {
+            "description": "This is a Description of the action",
+            "actions": [
+                {
+                    "action": {
+                        "track": {
+                            "Nth": 0,
+                            "attributes": {
+                                "detection": {
+                                    "mouseState": {
+                                        "op": "=",
+                                        "val": "scratching"
+                                    }
+                                }
+                            },
+                            "direction": "next",
+                            "startFrame": -1,
+                            "startTrack": -1,
+                            "type": "TrackSelection",
+                            "typeFilter": [
+                                "mouse"
+                            ]
+                        },
+                        "type": "GoToFrame"
+                    }
+                }
+            ]
+        }
+    ]
+}
+```
+
+Below adds a keyboard shortcut that will be added tied to the action.  Now when hitting `shift+p` it will perform the actions.
+
+```
+{
+    "text": "Testing the Actions Listing",
+    "diveActions": [
+        {
+            "description": "This is a Description of the action",
+            "shortcut": {
+                "key": "p",
+                "modifiers": ["shift"]
+            },
+            "actions": [
+                {
+                    "action": {
+                        "track": {
+                            "Nth": 0,
+                            "attributes": {
+                                "detection": {
+                                    "mouseState": {
+                                        "op": "=",
+                                        "val": "scratching"
+                                    }
+                                }
+                            },
+                            "direction": "next",
+                            "startFrame": -1,
+                            "startTrack": -1,
+                            "type": "TrackSelection",
+                            "typeFilter": [
+                                "mouse"
+                            ]
+                        },
+                        "type": "GoToFrame"
+                    }
+                }
+            ]
+        }
+    ]
+}
+```
+
+### Type Definitions
+
+UI Notification Type definition. Note:  a `?` at the end of a key means it is optional in Typescript
+```
+export interface UINotification {
+    datasetId: string[];
+    text: string;
+    selectedFrame?: number;
+    selectedTrack?: number;
+    reloadAnnotations?: boolean;
+    diveActions?: UIDIVEAction[];
+}
+```
+
+The UIDIVEAction allows for executing actions or for creating shortcuts.
+
+
+```
+export interface UIDIVEAction {
+  shortcut?: {
+    key: string;
+    modifiers?: string[]; //list of modifiers for the keyboard shortcut
+  }
+  description?: string;
+  applyConfig?: boolean; //Add to the system configuration the shortcut/action
+  actions: DIVEAction[];
+}
+```

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -413,6 +413,11 @@ class DIVEShortcut(BaseModel):
     description: str
     actions: List[DIVEActions]
 
+class DIVEUIAction(BaseModel):
+    shortcut: Optional[DIVEShortcut]
+    description: Optional[str]
+    applyConfig: Optional[bool]
+    actions: List[DIVEActions]
 
 class FilterTimeline(BaseModel):
     name: str

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -413,11 +413,13 @@ class DIVEShortcut(BaseModel):
     description: str
     actions: List[DIVEActions]
 
+
 class DIVEUIAction(BaseModel):
     shortcut: Optional[DIVEShortcut]
     description: Optional[str]
     applyConfig: Optional[bool]
     actions: List[DIVEActions]
+
 
 class FilterTimeline(BaseModel):
     name: str


### PR DESCRIPTION
resolves #156 

This PR should add the ability to execute actions and create shortcuts for specific actions in the system.

Done:
- Actions are added to the type definition for the UI Notification and can be used to execute simple `GoToFrame` and `TrackSelection` actions.
- There is a text description of the action and what it does.

TODO:

- [x] Add the ability to store temporary shortcuts that can be used after a UINotification creates them.
- [x] Executing and enabling new shortcuts including adding them to the shortcut listing
- [x] I think I should allow overriding user shortcuts from the UINotification System in-case tasks are run multiple times
- [x] The endpoint should notify and error if the user is attempting to overwrite a system shortcut
- [x] Allow creating configuration changes by adding a system shortcut to the configuration through the UINotification
- [x] Update documentation to show adding shortcuts using the UI system.