### PR TITLE
Aggregate Updates

### DIFF
--- a/client/dive-common/components/Attributes/AttributesSubsection.vue
+++ b/client/dive-common/components/Attributes/AttributesSubsection.vue
@@ -4,6 +4,7 @@ import {
   defineComponent,
   ref,
   PropType,
+  Ref,
   computed,
 } from 'vue';
 import {
@@ -77,6 +78,8 @@ export default defineComponent({
       return null;
     });
 
+    const highlightedAttribute: Ref<Attribute | null> = ref(null);
+
     // Using Revision to nudge the attributes after updating them
     const selectedAttributes = computed(() => {
       if (selectedTrack.value && selectedTrack.value.revision.value) {
@@ -107,7 +110,7 @@ export default defineComponent({
       if (selectedAttributes.value && selectedAttributes.value.attributes) {
         attributeVals = selectedAttributes.value.attributes;
       }
-      return sortAndFilterAttributes(props.attributes, mode, attributeVals, sortingMode.value, additionFilters);
+      return sortAndFilterAttributes(props.attributes, mode, attributeVals, sortingMode.value, additionFilters, highlightedAttribute.value);
     });
 
     const activeAttributesCount = computed(
@@ -189,6 +192,12 @@ export default defineComponent({
       return undefined;
     }
 
+    const selectAttributeRow = (attribute: Attribute) => {
+      console.log('selecting attribute');
+      console.log(attribute);
+      highlightedAttribute.value = attribute;
+    };
+
     return {
       frameRef,
       activeAttributesCount,
@@ -213,6 +222,8 @@ export default defineComponent({
       swimlaneActive,
       filtersActive,
       getUISetting,
+      highlightedAttribute,
+      selectAttributeRow,
     };
   },
 });
@@ -319,6 +330,58 @@ export default defineComponent({
           class="blank-spacer"
         />
       </v-row>
+      <v-row
+        v-if="highlightedAttribute !== null "
+        class="align-center selected-section"
+        no-gutters
+      >
+        <v-col dense>
+          <b class="attribute-header">Selected Attribute:</b>
+          <div
+            no-gutters
+            class="text-caption"
+          >
+            <div
+              class="type-color-box"
+              :style="{
+                backgroundColor: highlightedAttribute.color,
+              }"
+            /><span>{{ highlightedAttribute.name }}:
+            </span>
+          </div>
+        </v-col>
+        <tooltip-btn
+          icon="mdi-close-octagon-outline"
+          color="error"
+          tooltip-text="Deselect Attribute"
+          @click="highlightedAttribute = null"
+        />
+
+        <tooltip-btn
+          icon="mdi-chevron-double-left"
+          tooltip-text="Seek to First Value"
+        />
+
+        <tooltip-btn
+          icon="mdi-chevron-left"
+          tooltip-text="Seek to previous Value"
+        />
+
+        <tooltip-btn
+          icon="mdi-chevron-right"
+          tooltip-text="Seek to next Value"
+        />
+
+        <tooltip-btn
+          icon="mdi-chevron-double-right"
+          tooltip-text="Seek to end Value"
+        />
+        <tooltip-btn
+          icon="mdi-delete-variant"
+          color="yellow"
+          tooltip-text="Clear all attribute values"
+        />
+      </v-row>
     </template>
 
     <template
@@ -334,6 +397,10 @@ export default defineComponent({
         <span
           v-for="(attribute) of filteredFullAttributes"
           :key="attribute.name"
+          :class="{
+            'detection-row': mode === 'Detection' && !(highlightedAttribute !== null && highlightedAttribute.key === attribute.key),
+            'highlighted-row': highlightedAttribute !== null && highlightedAttribute.key === attribute.key,
+          }"
         >
           <v-row
             v-if="
@@ -341,8 +408,12 @@ export default defineComponent({
                 || selectedAttributes.attributes[attribute.name] !== undefined
             "
             class="ma-0"
+            :class="{
+              'highlighted-row': highlightedAttribute !== null && highlightedAttribute.key === attribute.key,
+            }"
             dense
             align="center"
+            @click="selectAttributeRow(attribute)"
           >
             <v-col class="attribute-name"> <div
               class="type-color-box"
@@ -442,6 +513,20 @@ export default defineComponent({
   min-height: 28px;
   max-width: 28px;
   max-height: 28px;
+}
+
+.highlighted-row {
+  background-color: #005fa288;
+}
+
+.detection-row {
+  :hover {
+    background-color: #005fa2;
+  }
+}
+
+.selected-section {
+  border-top: 1px solid gray;
 }
 
 </style>

--- a/client/dive-common/components/Attributes/AttributesSubsection.vue
+++ b/client/dive-common/components/Attributes/AttributesSubsection.vue
@@ -6,6 +6,7 @@ import {
   PropType,
   Ref,
   computed,
+  watch,
 } from 'vue';
 import {
   useSelectedTrackId,
@@ -200,6 +201,15 @@ export default defineComponent({
     const selectAttributeRow = (attribute: Attribute) => {
       highlightedAttribute.value = attribute;
     };
+
+    watch(() => props.attributes, () => {
+      if (highlightedAttribute.value) {
+        const found = filteredFullAttributes.value.find((item) => item.key === highlightedAttribute.value?.key);
+        if (found) {
+          highlightedAttribute.value = found;
+        }
+      }
+    });
 
     const seekToAttribute = (attribute: Attribute, action: 'first' | 'last' | 'next' | 'prev') => {
       if (selectedTrackIdRef.value !== null) {
@@ -446,7 +456,7 @@ export default defineComponent({
       >
         <span
           v-for="(attribute) of filteredFullAttributes"
-          :key="attribute.name"
+          :key="`${attribute.name}_${attribute.user}`"
           :class="{
             'detection-row': mode === 'Detection' && !(highlightedAttribute !== null && highlightedAttribute.key === attribute.key),
             'highlighted-row': highlightedAttribute !== null && highlightedAttribute.key === attribute.key,

--- a/client/dive-common/components/Attributes/AttributesSubsection.vue
+++ b/client/dive-common/components/Attributes/AttributesSubsection.vue
@@ -24,6 +24,7 @@ import context from 'dive-common/store/context';
 import { UISettingsKey } from 'vue-media-annotator/ConfigurationManager';
 import { useStore } from 'platform/web-girder/store/types';
 import { StringKeyObject } from 'vue-media-annotator/BaseAnnotation';
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 
 export default defineComponent({
   components: {
@@ -51,6 +52,8 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const readOnlyMode = useReadOnlyMode();
+    const { prompt } = usePrompt();
+
     const { frame: frameRef } = useTime();
     const selectedTrackIdRef = useSelectedTrackId();
     const store = useStore();
@@ -215,7 +218,16 @@ export default defineComponent({
       }
     };
 
-    const clearFeatureAttributes = (attribute: Attribute) => {
+    const clearFeatureAttributes = async (attribute: Attribute) => {
+      const result = await prompt({
+        title: 'Confirm',
+        text: `Do you want to delete all of ${attribute.name} values?`,
+        confirm: true,
+      });
+      if (!result) {
+        return;
+      }
+
       if (selectedTrackIdRef.value !== null) {
         // Tracks across all cameras get the same attributes set if they are linked
         const track = cameraStore.getTrack(selectedTrackIdRef.value);
@@ -414,7 +426,7 @@ export default defineComponent({
           @click="seekToAttribute(highlightedAttribute, 'last')"
         />
         <tooltip-btn
-          icon="mdi-delete-variant"
+          icon="mdi-delete-alert"
           color="yellow"
           tooltip-text="Clear all attribute values"
           @click="clearFeatureAttributes(highlightedAttribute)"

--- a/client/dive-common/components/configurationEditors/uiSettings.vue
+++ b/client/dive-common/components/configurationEditors/uiSettings.vue
@@ -51,7 +51,7 @@ export default defineComponent({
     const setVal = (key: keyof UISettings, val: boolean) => {
       const keyVal = configMan.getUISettingValue(key);
       if (keyVal !== undefined) {
-        if (typeof (keyVal) === 'object') {
+        if (typeof (keyVal) === 'object' && val) {
           return keyVal;
         }
         return val;

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -812,6 +812,10 @@ export default function useModeManager({
     }
   }
 
+  function seekFrame(frame: number) {
+    aggregateController.value.seek(frame);
+  }
+
   return {
     selectedTrackId,
     editingGroupId,
@@ -852,6 +856,7 @@ export default function useModeManager({
       stopLinking: handleStopLinking,
       processAction,
       addFullFrameTrack,
+      seekFrame,
     },
   };
 }

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.10.16",
+  "version": "1.10.17",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -162,6 +162,7 @@ export default defineComponent({
         data.frame = Math.floor(newFrame);
         data.flick = Math.round(video.currentTime * Flick);
         data.syncedFrame = data.frame;
+        props.updateTime(data);
         geoViewer.value.scheduleAnimationFrame(syncWithVideo);
       }
       data.currentTime = video.currentTime;

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -208,7 +208,7 @@ export interface Handler {
   addFullFrameTrack(trackType: string, trackLength: number): void;
   processAction(action: DIVEAction,
     shorcut?: boolean, data?: {frame?: number; selectedTrack?: number}): void;
-
+  seekFrame(frame: number): void;
 }
 const HandlerSymbol = Symbol('handler');
 
@@ -249,6 +249,7 @@ function dummyHandler(handle: (name: string, args: unknown[]) => void): Handler 
     stopLinking(...args) { handle('stopLinking', args); },
     addFullFrameTrack(...args) { handle('addFullFrameTrack', args); },
     processAction(...args) { handle('processAction', args); },
+    seekFrame(...args) { handle('seekFrame', args); },
   };
 }
 

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -45,7 +45,7 @@ export interface AttributesFilterType {
   addAttributeFilter: (index: number, type: Attribute['belongs'], filter: AttributeFilter) => void;
   modifyAttributeFilter: (index: number, type: Attribute['belongs'], filter: AttributeFilter) => void;
   deleteAttributeFilter: (index: number, type: Attribute['belongs']) => void;
-  sortAndFilterAttributes: (attributeList: Attribute[], mode: Attribute['belongs'], attribVals: StringKeyObject, sortingMode: number, filters: AttributeFilter[]) => Attribute[];
+  sortAndFilterAttributes: (attributeList: Attribute[], mode: Attribute['belongs'], attribVals: StringKeyObject, sortingMode: number, filters: AttributeFilter[], highlightedAttribute: Attribute | null) => Attribute[];
   setTimelineEnabled: (name: string, val: boolean) => void;
   setTimelineGraph: (name: string, filter: TimelineGraph) => void;
   setTimelineDefault: (name: string) => void;

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -499,7 +499,10 @@ export default class Track extends BaseAnnotation {
       let modified = false;
       if (this.features[frame]) {
         if (user !== null) {
-          if (this.features[frame].attributes !== undefined && (this.features[frame].attributes as StringKeyObject).userAttributes !== undefined && ((((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[user] as StringKeyObject)[name] !== undefined)) {
+          if (this.features[frame].attributes !== undefined
+            && (this.features[frame].attributes as StringKeyObject).userAttributes !== undefined
+            && (((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[user])
+            && ((((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[user] as StringKeyObject)[name] !== undefined)) {
             modified = true;
             delete (((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[user] as StringKeyObject)[name];
           }

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -520,7 +520,10 @@ export default class Track extends BaseAnnotation {
       const { frame } = feature;
       if (this.features[frame]) {
         if (user !== null) {
-          if (this.features[frame].attributes !== undefined && (this.features[frame].attributes as StringKeyObject).userAttributes !== undefined && ((((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[user] as StringKeyObject)[name] !== undefined)) {
+          if (this.features[frame].attributes !== undefined
+            && (this.features[frame].attributes as StringKeyObject).userAttributes !== undefined
+            && (((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[user])
+            && ((((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[user] as StringKeyObject)[name] !== undefined)) {
             frameListing.push(frame);
           }
         } else if (this.features[frame].attributes && (this.features[frame].attributes as StringKeyObject)[name] !== undefined) {

--- a/client/src/track.ts
+++ b/client/src/track.ts
@@ -468,6 +468,27 @@ export default class Track extends BaseAnnotation {
     };
   }
 
+  clearFeatureAttributeValues(name: string, user: null | string = null) {
+    this.features.forEach((feature) => {
+      const { frame } = feature;
+      let modified = false;
+      if (this.features[frame]) {
+        if (user !== null) {
+          if (this.features[frame].attributes !== undefined && (this.features[frame].attributes as StringKeyObject).userAttributes === undefined && (((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[name] !== undefined)) {
+            modified = true;
+            delete ((this.features[frame].attributes as StringKeyObject).userAttributes as StringKeyObject)[name];
+          }
+        } else if (this.features[frame].attributes && (this.features[frame].attributes as StringKeyObject)[name] !== undefined) {
+          modified = true;
+          delete (this.features[frame].attributes as StringKeyObject)[name];
+        }
+      }
+      if (modified) {
+        this.notify('feature', this.features[frame]);
+      }
+    });
+  }
+
   /* Interpolate feature from d0 to d1 @ frame */
   static interpolate(frame: number, d0: Feature, d1: Feature): Feature | null {
     if (!d0.interpolate) {

--- a/client/src/use/useAttributes.ts
+++ b/client/src/use/useAttributes.ts
@@ -268,9 +268,20 @@ export default function UseAttributes(
    * @param filters - list of filters to applie
    * @returns - sorted list of attributes
    */
-  function sortAndFilterAttributes(attributeList: Attribute[], mode: Attribute['belongs'], attribVals: StringKeyObject, sortingMode: number, filters: AttributeFilter[]) {
+  function sortAndFilterAttributes(attributeList: Attribute[], mode: Attribute['belongs'], attribVals: StringKeyObject, sortingMode: number, filters: AttributeFilter[], highlightedAttribute: Attribute | null = null) {
     const sortedAttributes = sortAttributes(attributeList, mode, attribVals, sortingMode);
     const filteredAttributes = filterAttributes(sortedAttributes, mode, attribVals, filters);
+    if (highlightedAttribute) {
+      filteredAttributes.sort((a, b) => {
+        if (a.key === highlightedAttribute.key && b.key !== highlightedAttribute.key) {
+          return -1;
+        }
+        if (a.key !== highlightedAttribute.key && b.key === highlightedAttribute.key) {
+          return 1;
+        }
+        return 0; // Keeps the original order for other elements
+      });
+    }
     return filteredAttributes;
   }
 

--- a/client/src/use/useAttributes.ts
+++ b/client/src/use/useAttributes.ts
@@ -624,6 +624,9 @@ export default function UseAttributes(
           const userAttr = feature.attributes.userAttributes[login] as StringKeyObject;
           Object.keys(userAttr).forEach((key) => {
             const baseAttribute = attributesList.value.find((item) => item.name === key);
+            if (!baseAttribute?.user) {
+              return;
+            }
             if (feature.attributes?.userAttributes && feature.attributes.userAttributes[login] && (userAttr[key] !== undefined)) {
               const val = processSwimlaneKey(key, valueMap, filter, track, frame, userAttr, baseAttribute, settings, colorScalingNumbers, lastValue);
               if (val !== null) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@
 # Use YAML anchors for the common config between both workers
 x-worker: &base-worker
   ipc: host
+  platform: 'linux/amd64'
   build:
     context: .
     dockerfile: docker/girder_worker.Dockerfile
@@ -50,6 +51,7 @@ services:
       - ${MONGO_DB_PATH:-mongo_db}:/data/db
 
   girder:
+    platform: 'linux/amd64'
     build:
       context: .
       dockerfile: docker/girder.Dockerfile

--- a/server/dive_server/views_dataset.py
+++ b/server/dive_server/views_dataset.py
@@ -341,12 +341,12 @@ class DatasetResource(Resource):
         accessList = Folder().getFullAccessList(folder)
         accessUsers = accessList['users']
         userList = []
-        for user in accessUsers:
-            if user['level'] == 2:
+        for subUser in accessUsers:
+            if subUser['level'] == 2:
                 userList.append(
                     {
-                        "name": user['login'],
-                        "id": str(user["id"]),
+                        "name": subUser['login'],
+                        "id": str(subUser["id"]),
                     }
                 )
         accessGroups = accessList['groups']
@@ -445,7 +445,7 @@ class DatasetResource(Resource):
             str(folderParentId), level=AccessType.READ, user=user, force=True
         )
         childFolders = list(
-            Folder().childFolders(folderParent, folderParentType, sort=[['lowerName', 1]])
+            Folder().childFolders(folderParent, folderParentType, sort=[['lowerName', 1]], user=user)
         )
         for index, item in enumerate(childFolders):
             if item.get('_id') == folder.get('_id'):

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -139,8 +139,9 @@ def convert_video(
         )
         jsoninfo = json.loads(stdout)
         videostream = list(filter(lambda x: x["codec_type"] == "video", jsoninfo["streams"]))
+        multiple_video_streams = None
         if len(videostream) != 1:
-            raise Exception('Expected 1 video stream, found {}'.format(len(videostream)))
+            multiple_video_streams = "More than One video stream found, defaulting to the first stream"
 
         # Extract average framerate
         avgFpsString: str = videostream[0]["avg_frame_rate"]
@@ -176,6 +177,9 @@ def convert_video(
                     "codec": "h264",
                 },
             )
+            ffprobe_info = videostream[0]
+            if multiple_video_streams:
+                ffprobe_info['multiple_video_streams'] = multiple_video_streams
             gc.addMetadataToFolder(
                 folderId,
                 {
@@ -184,7 +188,8 @@ def convert_video(
                     constants.OriginalFPSStringMarker: avgFpsString,
                     constants.FPSMarker: newAnnotationFps,
                     constants.MarkForPostProcess: False,
-                    "ffprobe_info": videostream[0],
+                    "ffprobe_info": ffprobe_info,
+
                 },
             )
             return


### PR DESCRIPTION
resolves #178 
resolves #176 
resolves #175 
resolves #174 

- Fix prev/next not showing up in certain Collections
- Use first video stream if multiple streams are found, note this in the ffprobe metadata for the Dataset
- Allowed setting attribute values while playback is occurring.  This was just syncing the timeObserver function with the video properly.
- Concept of selected Attribute that can be used to browse the first, prev, next, last location of attribute values being set.  Also allows for clearing a whole attribute.
- Now to the left of swimlanes is an area that when clicked will provide a symbol for each location where there is an attribute value.
- Track Detection Attributes can be deleted all at once from the new selection interface.
- Guard against deletion of attributes with a prompt
- SideBar Disabling in the UI Configuration collapsing should remove the entire sidebar from the interface.
    - When disabling sideBar it sets it to `{}` instead of `false` this needs to be updated.
- userAttribute switching for graphing is now improved and switching between them in the viewer will graph new values

