### PR TITLE
create track full frame action

### DIFF
--- a/.github/workflows/workflow-dive-dsa-slicer.yml
+++ b/.github/workflows/workflow-dive-dsa-slicer.yml
@@ -25,7 +25,7 @@ jobs:
         name: Build and push web
         uses: docker/build-push-action@v3
         with:
-          context: ./dive-dsa-slicer
+          context: ./dive-dsa-slicer/example-docker-containers
           file: ./dive-dsa-slicer/example-docker-containers/Dockerfile
           tags: ghcr.io/digitalslidearchive/dive-dsa/dive-dsa-slicer-examples:latest
           push: true

--- a/client/dive-common/components/ActionEditors/ActionEditorSettings.vue
+++ b/client/dive-common/components/ActionEditors/ActionEditorSettings.vue
@@ -44,7 +44,7 @@ export default defineComponent({
     const typeStylingRef = useTrackStyleManager().typeStyling;
     const attributesList = useAttributes();
     const editingAction: Ref<null | DIVEAction> = ref(null);
-    const addEditActionType: Ref<'TrackSelection' | 'GoToFrame'> = ref('TrackSelection');
+    const addEditActionType: Ref<'TrackSelection' | 'GoToFrame' | 'CreateTrackAction' | 'CreateFullFrameTrackAction'> = ref('TrackSelection');
     const editAction = (index?: number) => {
       addEditAction.value = true;
       if (index !== undefined) {
@@ -94,6 +94,27 @@ export default defineComponent({
         editingAction.value = {
           action: {
             type: 'TrackSelection',
+          },
+        };
+      }
+      if (addEditActionType.value === 'CreateTrackAction') {
+        editingAction.value = {
+          action: {
+            type: 'CreateTrackAction',
+            geometryType: 'rectangle',
+            editableType: true,
+            selectTrackAfter: true,
+          },
+        };
+      }
+      if (addEditActionType.value === 'CreateFullFrameTrackAction') {
+        editingAction.value = {
+          action: {
+            type: 'CreateFullFrameTrackAction',
+            trackType: 'unknown',
+            geometryType: 'rectangle',
+            useExisting: true,
+            selectTrackAfter: true,
           },
         };
       }
@@ -172,9 +193,11 @@ export default defineComponent({
               :key="`ActionItem_${index}`"
               dense
               style="border: 1px gray solid; margin:2px"
+              align="center"
+              justify="center"
             >
-              <v-col cols="2">
-                {{ item.action.type }}
+              <v-col cols="3">
+                <span style="font-size: 10px">{{ item.action.type }}</span>
               </v-col>
               <v-col v-if="item.action.type === 'TrackSelection'">
                 <v-row
@@ -190,6 +213,26 @@ export default defineComponent({
                   />
                   {{ trackType }}
                 </v-row>
+              </v-col>
+              <v-col v-if="item.action.type === 'CreateFullFrameTrackAction'">
+                <v-row dense>
+                  <span class="mr-2">{{ item.action.trackType }}:</span>
+                  <div
+                    class="type-color-box"
+                    :style="{
+                      backgroundColor: typeStylingRef.color(item.action.trackType),
+                    }"
+                  />
+                </v-row>
+                <v-row dense>
+                  <span>Geometry: {{ item.action.geometryType }}</span>
+                </v-row>
+              </v-col>
+              <v-col v-if="item.action.type === 'CreateFullFrameTrackAction'">
+                <span class="mr-1"> Use Existing: </span>
+                <v-icon> {{ item.action.useExisting ? 'mdi-checkbox-outline' : 'mdi-checkobx-blank-outline' }}</v-icon>
+                <span class="ml-3 mr-1"> Select Track After: </span>
+                <v-icon> {{ item.action.selectTrackAfter ? 'mdi-checkbox-outline' : 'mdi-checkobx-blank-outline' }}</v-icon>
               </v-col>
               <v-col v-if="item.action.type === 'GoToFrame' && item.action.track">
                 <v-row
@@ -221,6 +264,7 @@ export default defineComponent({
                   {{ data.name }}: {{ data.opVal }}
                 </v-row>
               </v-col>
+              <v-spacer />
               <v-col cols="1">
                 <v-icon @click="editAction(index)">
                   mdi-pencil

--- a/client/dive-common/components/ActionEditors/ActionShortcuts.vue
+++ b/client/dive-common/components/ActionEditors/ActionShortcuts.vue
@@ -49,7 +49,7 @@ export default defineComponent({
     const typeStylingRef = useTrackStyleManager().typeStyling;
     const attributesList = useAttributes();
     const editingShortcut: Ref<null | DIVEActionShortcut> = ref(null);
-    const addEditActionType: Ref<'TrackSelection' | 'GoToFrame'> = ref('TrackSelection');
+    const addEditActionType: Ref<'TrackSelection' | 'GoToFrame' | 'CreateTrackAction' | 'CreateFullFrameTrackAction'> = ref('TrackSelection');
     const actionList: Ref<DIVEAction[]> = ref([]);
     const updateActionList = () => {
       actionList.value = editingShortcut.value?.actions || [];
@@ -160,10 +160,9 @@ export default defineComponent({
 
     const saveShortcutDisabled = computed(() => {
       if (editingShortcut.value) {
-        const { key } = editingShortcut.value.shortcut;
         const { description } = editingShortcut.value;
         const actionLength = editingShortcut.value.actions.length;
-        return !(key && description && actionLength);
+        return !(description && actionLength);
       }
       return false;
     });
@@ -216,18 +215,58 @@ export default defineComponent({
         <v-card-title>Action Shortcut Editor</v-card-title>
         <v-card-text>
           <div v-if="!addEditShortcut">
-            <v-row dnese>
+            <v-row dense class="pb-3">
               <v-btn @click="editShortcut()">
                 Add Shortcut
               </v-btn>
             </v-row>
+            <v-row dense style="border-bottom: 1px solid gray;">
+              <v-col>
+                <span>
+                  <v-icon class="mr-2">mdi-keyboard-outline</v-icon><b>Keyboard</b>
+                </span>
+              </v-col>
+              <v-col>
+                <span>
+                  <v-icon class="mr-2">mdi-button-cursor</v-icon><b>Button</b>
+                </span>
+              </v-col>
+              <v-col>
+                <span>
+                  <b>Description</b>
+                </span>
+              </v-col>
+              <v-col>
+                <span>
+                  <b>Actions</b>
+                </span>
+              </v-col>
+              <v-col cols="1">
+                <span>
+                  <b>Edit</b>
+                </span>
+              </v-col>
+            </v-row>
+
             <v-row
               v-for="item, index in shortcutList"
               :key="`shortcut_${item.shortcut.key}_${index}`"
               dense
+              align="center"
+              justify="center"
             >
               <v-col>
-                {{ item.shortcut.key }}{{ item.shortcut.modifiers && item.shortcut.modifiers.length ? `+${item.shortcut.modifiers.join('+')}` : '' }}
+                <span v-if="item.shortcut.key">
+                  <v-icon class="mr-2">mdi-keyboard-outline</v-icon>{{ item.shortcut.key }}{{ item.shortcut.modifiers && item.shortcut.modifiers.length ? `+${item.shortcut.modifiers.join('+')}` : '' }}
+                </span>
+              </v-col>
+              <v-col>
+                <span v-if="item.button">
+                  <v-icon class="mr-2">mdi-button-cursor</v-icon>
+                  <v-icon v-if="item.button.iconPrepend">{{ item.button.iconPrepend }}</v-icon>
+                  <span v-if="item.button.buttonText">{{ item.button.buttonText }}</span>
+                  <v-icon v-if="item.button.iconAppend">{{ item.button.iconAppend }}</v-icon>
+                </span>
               </v-col>
               <v-col>
                 {{ item.description }}
@@ -272,7 +311,7 @@ export default defineComponent({
                 dense
                 style="border: 1px gray solid; margin:2px"
               >
-                <v-col cols="2">
+                <v-col cols="3">
                   {{ item.action.type }}
                 </v-col>
                 <v-col v-if="item.action.type === 'TrackSelection'">
@@ -320,6 +359,33 @@ export default defineComponent({
                     {{ data.name }}: {{ data.opVal }}
                   </v-row>
                 </v-col>
+                <v-col v-if="item.action.type === 'CreateTrackAction'">
+                  <div v-if="item.action.editableType">
+                    <b class="mr-2">Editable Type:</b><v-icon v-if="item.action.editableType" color="success">
+                      mdi-check
+                    </v-icon><v-icon v-else color="error">
+                      mdi-close
+                    </v-icon>
+                  </div>
+                  <div v-if="item.action.editableTypeList?.length">
+                    <b class="mr-2">Types:</b><span>{{ item.action.editableTypeList.join(', ') }}</span>
+                  </div>
+                  <div v-if="item.action.trackType">
+                    <b class="mr-2">Type:</b><span>{{ item.action.trackType }}</span>
+                  </div>
+                  <div v-if="item.action.geometryType">
+                    <b class="mr-2">Geometry:</b><span>{{ item.action.geometryType }}</span>
+                  </div>
+
+                  <div>
+                    <b class="mr-2">Select Track After:</b><v-icon v-if="item.action.selectTrackAfter" color="success">
+                      mdi-check
+                    </v-icon><v-icon v-else color="error">
+                      mdi-close
+                    </v-icon>
+                  </div>
+                </v-col>
+                <v-spacer />
                 <v-col cols="1">
                   <v-icon @click="editAction(index)">
                     mdi-pencil
@@ -380,18 +446,22 @@ export default defineComponent({
           </v-row>
         </v-card-text>
         <v-card-actions>
-          <v-btn
-            x-small
-            @click="generalDialog = false; editingShortcut = null; addEditShortcut = false"
-          >
-            Cancel
-          </v-btn>
-          <v-btn
-            color="primary"
-            @click="save()"
-          >
-            Save
-          </v-btn>
+          <v-row dense>
+            <v-spacer />
+            <v-btn
+              class="mx-2"
+              @click="generalDialog = false; editingShortcut = null; addEditShortcut = false"
+            >
+              Cancel
+            </v-btn>
+            <v-btn
+              class="mx-2"
+              color="primary"
+              @click="save()"
+            >
+              Save
+            </v-btn>
+          </v-row>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/client/dive-common/components/ActionEditors/CreateFullFrameTrackActionEditor.vue
+++ b/client/dive-common/components/ActionEditors/CreateFullFrameTrackActionEditor.vue
@@ -1,0 +1,95 @@
+<script lang="ts">
+import {
+  defineComponent, PropType, ref,
+} from 'vue';
+import { EditAnnotationTypes } from 'vue-media-annotator/layers/';
+import { CreateFullFrameTrackAction } from 'dive-common/use/useActions';
+
+export default defineComponent({
+  name: 'EditFullFrameTrackAction',
+  props: {
+    action: {
+      type: Object as PropType<CreateFullFrameTrackAction>,
+      required: true,
+    },
+  },
+  emits: ['update:action', 'cancel'],
+  setup(props, { emit }) {
+    const geometryTypes: EditAnnotationTypes[] = ['rectangle', 'Time'];
+    const localAction = ref({ ...props.action });
+    const cancel = () => {
+      emit('cancel');
+    };
+    const save = () => {
+      emit('update:action', localAction.value);
+    };
+    return {
+      localAction,
+      geometryTypes,
+      cancel,
+      save,
+    };
+  },
+});
+</script>
+
+<template>
+  <div class="ma-2 action-editor">
+    <v-card>
+      <v-card-title>Edit: Create  Full Frame Track Action</v-card-title>
+      <v-card-text>
+        <v-select
+          v-model="localAction.geometryType"
+          :items="geometryTypes"
+          label="Geometry Type"
+          outlined
+          dense
+        />
+
+        <!-- Editable Type Toggle -->
+
+        <!-- Editable Title and Text (Shown if Editable Type is On) -->
+        <v-text-field
+          v-model="localAction.trackType"
+          label="Track Type"
+          outlined
+          dense
+        />
+        <!-- Select Track After -->
+        <v-checkbox
+          v-model="localAction.useExisting"
+          label="Use Existing Track"
+          class="mt-2"
+        />
+
+        <v-checkbox
+          v-model="localAction.selectTrackAfter"
+          label="Select Track After"
+          class="mt-2"
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-row dense>
+          <v-spacer />
+          <v-btn class="mx-2" @click="cancel">
+            Cancel
+          </v-btn>
+          <v-btn
+            color="primary"
+            class="mx-2"
+            @click="save"
+          >
+            Save
+          </v-btn>
+        </v-row>
+      </v-card-actions>
+    </v-card>
+  </div>
+</template>
+
+<style scoped>
+.action-editor {
+  width: 100%;
+  border: 1px solid gray;
+}
+</style>

--- a/client/dive-common/components/ActionEditors/CreateTrackActionEditor.vue
+++ b/client/dive-common/components/ActionEditors/CreateTrackActionEditor.vue
@@ -1,0 +1,155 @@
+<script lang="ts">
+import {
+  defineComponent, PropType, ref, Ref,
+  watch,
+} from 'vue';
+import { EditAnnotationTypes } from 'vue-media-annotator/layers/';
+import { CreateTrackAction } from 'dive-common/use/useActions';
+
+export default defineComponent({
+  name: 'EditTrackAction',
+  props: {
+    action: {
+      type: Object as PropType<CreateTrackAction>,
+      required: true,
+    },
+  },
+  emits: ['update:action', 'cancel'],
+  setup(props, { emit }) {
+    const geometryTypes: EditAnnotationTypes[] = ['Point', 'rectangle', 'Polygon', 'LineString', 'Time'];
+    const localAction = ref({ ...props.action });
+    const editableTypeListEnabled = ref(false);
+    const editableTypeList: Ref<string> = ref('');
+    watch(editableTypeList, () => {
+      localAction.value.editableTypeList = editableTypeList.value.split(',').map((type) => type.trim());
+    });
+    const cancel = () => {
+      emit('cancel');
+    };
+    const save = () => {
+      emit('update:action', localAction.value);
+    };
+    return {
+      localAction,
+      geometryTypes,
+      editableTypeList,
+      editableTypeListEnabled,
+      cancel,
+      save,
+    };
+  },
+});
+</script>
+
+<template>
+  <div class="ma-2 action-editor">
+    <v-card>
+      <v-card-title>Edit: Create Track Action</v-card-title>
+      <v-card-text>
+        <v-select
+          v-model="localAction.geometryType"
+          :items="geometryTypes"
+          label="Geometry Type"
+          outlined
+          dense
+        />
+
+        <!-- Editable Type Toggle -->
+        <v-row dense align="center" justify="center">
+          <v-switch
+            v-model="localAction.editableType"
+            label="Editable Type"
+            class="mt-2 mr-2"
+          />
+          <v-tooltip
+            open-delay="200"
+            bottom
+          >
+            <template #activator="{ on }">
+              <v-icon class="mb-3" v-on="on">
+                mdi-help-circle
+              </v-icon>
+            </template>
+            <span>This enables a popup that will ask the user what type of track they want to create.  The Title and Text are the information displayed to the user</span>
+          </v-tooltip>
+          <v-spacer />
+        </v-row>
+
+        <!-- Editable Title and Text (Shown if Editable Type is On) -->
+        <v-text-field
+          v-if="localAction.editableType"
+          v-model="localAction.editableTitle"
+          label="Editable Title"
+          outlined
+          dense
+        />
+
+        <v-textarea
+          v-if="localAction.editableType"
+          v-model="localAction.editableText"
+          label="Editable Text"
+          outlined
+          dense
+        />
+
+        <v-row dense align="center" justify="center">
+          <v-switch
+            v-model="editableTypeListEnabled"
+            label="Type List"
+            class="mt-2 mr-2"
+          />
+          <v-tooltip
+            open-delay="200"
+            bottom
+          >
+            <template #activator="{ on }">
+              <v-icon class="mb-3" v-on="on">
+                mdi-help-circle
+              </v-icon>
+            </template>
+            <span>Provide a comma separate list of types that can be used</span>
+          </v-tooltip>
+          <v-spacer />
+        </v-row>
+
+        <v-text-field
+          v-if="editableTypeListEnabled"
+          v-model="editableTypeList"
+          label="Type List"
+          details="Comma separated list of types"
+          outlined
+          dense
+        />
+
+        <!-- Select Track After -->
+        <v-checkbox
+          v-model="localAction.selectTrackAfter"
+          label="Select Track After"
+          class="mt-2"
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-row dense>
+          <v-spacer />
+          <v-btn class="mx-2" @click="cancel">
+            Cancel
+          </v-btn>
+          <v-btn
+            color="primary"
+            class="mx-2"
+            @click="save"
+          >
+            Save
+          </v-btn>
+        </v-row>
+      </v-card-actions>
+    </v-card>
+  </div>
+</template>
+
+<style scoped>
+.action-editor {
+  width: 100%;
+  border: 1px solid gray;
+}
+</style>

--- a/client/dive-common/components/ActionEditors/TrackFilter.vue
+++ b/client/dive-common/components/ActionEditors/TrackFilter.vue
@@ -181,7 +181,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="ma-2">
+  <div class="ma-2 action-editor">
     <v-card>
       <v-card-title>Track Filter Creation</v-card-title>
       <v-card-text>
@@ -343,7 +343,7 @@ export default defineComponent({
         </v-row>
       </v-card-text>
       <v-card-actions>
-        <v-row>
+        <v-row dense>
           <v-spacer />
           <v-btn
             small
@@ -416,7 +416,7 @@ export default defineComponent({
           </v-row>
         </v-card-text>
         <v-card-actions>
-          <v-row>
+          <v-row dense>
             <v-spacer />
             <v-btn @click="cancelAttr">
               Cancel
@@ -442,6 +442,10 @@ export default defineComponent({
     max-width: 15px;
     min-height: 15px;
     max-height: 15px;
+  }
+  .action-editor {
+    width: 100%;
+    border: 1px solid gray;
   }
 
 </style>

--- a/client/dive-common/use/useActions.ts
+++ b/client/dive-common/use/useActions.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 import { StringKeyObject } from 'vue-media-annotator/BaseAnnotation';
+import { EditAnnotationTypes } from 'vue-media-annotator/layers';
 import { ButtonShortcut } from 'vue-media-annotator/use/AttributeTypes';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -34,7 +35,7 @@ export interface TrackSelectAction {
     direction?: 'next' | 'previous';
 }
 
-export type ActionTypes = 'GoToFrame' | 'SelectTrack' | 'Wait' | 'Popup';
+export type ActionTypes = 'GoToFrame' | 'SelectTrack' | 'Wait' | 'Popup' | 'CreateTrack' | 'CreateFullFrameTrack';
 
 export interface GoToFrameAction{
     track?: TrackSelectAction; // Go to first frame of track that matches conditions
@@ -42,8 +43,27 @@ export interface GoToFrameAction{
     type: 'GoToFrame';
 }
 
+export interface CreateTrackAction {
+  type: 'CreateTrackAction'; // trackType
+  trackType?: string;
+  geometryType: EditAnnotationTypes;
+  editableType: boolean;
+  editableTypeList?: string[];
+  editableTitle?: string;
+  editableText?: string;
+  selectTrackAfter: boolean;
+}
+
+export interface CreateFullFrameTrackAction {
+  type: 'CreateFullFrameTrackAction';
+  useExisting: boolean;
+  trackType: string;
+  geometryType: 'rectangle' | 'Time';
+  selectTrackAfter: boolean;
+}
+
 export interface DIVEAction {
-  action: GoToFrameAction | TrackSelectAction;
+  action: GoToFrameAction | TrackSelectAction | CreateTrackAction | CreateFullFrameTrackAction;
 }
 
 export interface DIVEActionShortcut {

--- a/client/dive-common/vue-utilities/prompt-service/Prompt.vue
+++ b/client/dive-common/vue-utilities/prompt-service/Prompt.vue
@@ -18,6 +18,7 @@ export default defineComponent({
     const value: Ref<string | boolean | number| null> = ref(null);
     const valueList: Ref<string[] | undefined> = ref(undefined);
     const lockedValueList = ref(true);
+    const allowNullValueList = ref(false);
 
     /**
      * Placeholder resolver function.  Wrapped in object so that
@@ -88,6 +89,10 @@ export default defineComponent({
     });
 
     watch(show, async (val) => {
+      if (!allowNullValueList.value && valueList.value?.length && valueList.value[0]) {
+      // eslint-disable-next-line prefer-destructuring
+        value.value = valueList.value[0];
+      }
       if (!val) {
         if (valueType.value === undefined) {
           functions.resolve(false);

--- a/client/dive-common/vue-utilities/prompt-service/index.ts
+++ b/client/dive-common/vue-utilities/prompt-service/index.ts
@@ -14,6 +14,7 @@ export interface PromptParams {
   valueList?: string[];
   confirm?: boolean;
   lockedValueList?: boolean;
+  allowNullValueList?: boolean;
 }
 
 class PromptService {
@@ -36,6 +37,7 @@ class PromptService {
     valueType?: 'text' | 'number' | 'boolean',
     valueList?: string[],
     lockedValueList?: boolean,
+    allowNullValueList?: boolean,
   ): void {
     this.component.title = title;
     this.component.text = text;
@@ -48,6 +50,7 @@ class PromptService {
     this.component.show = true;
     this.component.valueList = valueList;
     this.component.lockedValueList = lockedValueList;
+    this.component.allowNullValueList = allowNullValueList;
   }
 
   show({
@@ -78,6 +81,7 @@ class PromptService {
     confirm = false,
     valueList = undefined,
     lockedValueList = true,
+    allowNullValueList = true,
   }: PromptParams): Promise<boolean | number | string | null> {
     return new Promise<boolean | number | string | null>((resolve) => {
       if (!this.component.show) {
@@ -91,6 +95,7 @@ class PromptService {
           valueType,
           valueList,
           lockedValueList,
+          allowNullValueList,
         );
         return this.component.value;
       }

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.10.26",
+  "version": "1.10.27",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"

--- a/server/dive_server/crud_dataset.py
+++ b/server/dive_server/crud_dataset.py
@@ -311,6 +311,10 @@ def transfer_config(source: types.GirderModel, dest: types.GirderModel):
     customTypeStyling = source.get('meta', {}).get('customTypeStyling', {})
     confidenceFilters = source.get('meta', {}).get('confidenceFilters', {})
     filters = source.get('meta', {}).get('filters', {})
+    configuration = source.get('meta', {}).get('configuration', {})
+    if configuration:
+        if configuration.get('general', {}).get('baseConfiguration', False):
+            configuration['general']['baseConfiguration'] = str(dest['_id'])
     data = {
         'attributes': attributes,
         'timelines': timelines,
@@ -319,8 +323,9 @@ def transfer_config(source: types.GirderModel, dest: types.GirderModel):
         'customTypeStyling': customTypeStyling,
         'filters': filters,
         'confidenceFilters': confidenceFilters,
+        'configuration': configuration,
     }
-    update_metadata(dest, data, False)
+    return update_metadata(dest, data, False)
 
 
 def update_attributes(dsFolder: types.GirderModel, data: dict, verify=True):

--- a/server/dive_server/views_metadata.py
+++ b/server/dive_server/views_metadata.py
@@ -308,6 +308,7 @@ class DIVEMetadata(Resource):
                                     # add in DIVE Keys:
                                     item['DIVE_DatasetId'] = str(datasetFolder['_id'])
                                     item['DIVE_Name'] = datasetFolder['lowerName']
+                                    item['DIVE_Path'] = resource_path
                                     datasetFolder.get('name')
                                     if ffprobeMetadata.get(
                                         'import', False
@@ -467,6 +468,10 @@ class DIVEMetadata(Resource):
             data = {}
             data['DIVE_DatasetId'] = str(item['_id'])
             data['DIVE_Name'] = str(item['lowerName'])
+            resource_path = path_util.getResourcePath(
+                'folder', item, user=user
+            )
+            data['DIVE_Path'] = resource_path
             if ffprobeMetadata.get('import', False):  # Add in ffprobe metadata to the system
                 ffmetadata = item.get('meta', {}).get('ffprobe_info', {})
                 ffkeys = ffprobeMetadata.get('keys', [])

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -414,8 +414,27 @@ class GoToFrameAction(BaseModel):
     type: Literal['GoToFrame']
 
 
+class CreateTrackAction(BaseModel):
+    trackType: Optional[str]
+    geometryType: Literal['Point', 'rectangle', 'Polygon', 'LineString', 'Time']
+    editableType: bool
+    editableTitle: Optional[str]
+    editableText: Optional[str]
+    editableTypeList: Optional[List[str]]
+    selectTrackAfter: bool
+    type: Literal['CreateTrackAction']
+
+
+class CreateFullFrameTrackAction(BaseModel):
+    trackType: Optional[str]
+    geometryType: Literal['rectangle', 'Time']
+    useExisting: bool
+    selectTrackAfter: bool
+    type: Literal['CreateFullFrameTrackAction']
+
+
 class DIVEActions(BaseModel):
-    action: Union[GoToFrameAction, TrackSelectAction]
+    action: Union[GoToFrameAction, TrackSelectAction, CreateTrackAction, CreateFullFrameTrackAction]
 
 
 class ShortCut(BaseModel):


### PR DESCRIPTION
resolves #236 
resolves #237 
resolves #235

- Added opacity to single frame last swimlanes with a tooltip that describes the update
- Added the Path as a metadata key (DIVE_Path) for metadata import so it can be used for filtering.
- Added UI for transferring configuration to other folders.

Allows for creation of a full frame track on load or selecting the track if it is already created.