### PR TITLE
attribute and baseUI config upgrades

### DIFF
--- a/client/dive-common/components/CustomUI/CustomUIBase.vue
+++ b/client/dive-common/components/CustomUI/CustomUIBase.vue
@@ -15,6 +15,7 @@ import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { Attribute, AttributeShortcut } from 'vue-media-annotator/use/AttributeTypes';
 import { DIVEAction } from 'dive-common/use/useActions';
 import { StringKeyObject } from 'vue-media-annotator/BaseAnnotation';
+import context from 'dive-common/store/context';
 
 interface AttributeDisplayButton {
     name: string;
@@ -76,7 +77,7 @@ export default defineComponent({
     const title = computed(() => configMan.configuration.value?.customUI?.title || 'Custom Actions');
     const information = computed(() => configMan.configuration.value?.customUI?.information || []);
     const updatedWidth = computed(() => configMan.configuration.value?.customUI?.width || props.width);
-
+    context.nudgeWidth(updatedWidth.value);
     function getAttributeUser({ name, belongs }: { name: string; belongs: 'track' | 'detection' }) {
       const attribute = attributes.value.find((attr) => attr.name === name && attr.belongs === belongs);
       if (attribute?.user) {
@@ -128,7 +129,6 @@ export default defineComponent({
       if (shortcut.type === 'dialog') {
         handler = async () => {
           const value = getAttributeValue(attribute.name, attribute.belongs, !!attribute.user) as string | number | boolean | undefined;
-          console.log(`Input Value: ${value}`);
           const val = await inputValue({
             title: `Set ${attribute.name} Value`,
             text: attribute.values ? 'Press Spacebar to choose a selection, then Enter to select' : 'Set the Attribute Value below',
@@ -257,7 +257,6 @@ export default defineComponent({
     });
 
     const expandPanel = (buttonName: string) => {
-      console.log(`Expand Panel: ${buttonName}`);
       if (panelExpanded.value[buttonName] !== undefined) {
         panelExpanded.value[buttonName] = undefined;
       } else {
@@ -365,7 +364,7 @@ export default defineComponent({
               </v-tooltip>
             </v-col>
           </v-row>
-          <v-row v-if="buttonValueMap[attribute.name]" class="pa-2">
+          <v-row v-if="buttonValueMap[attribute.name]">
             <v-col cols="12">
               <span v-if="buttonValueMap[attribute.name].length < 50">
                 {{ buttonValueMap[attribute.name].value }}

--- a/client/dive-common/components/CustomUI/CustomUIBase.vue
+++ b/client/dive-common/components/CustomUI/CustomUIBase.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import {
-  defineComponent, computed,
+  defineComponent, computed, ref,
+  Ref,
 } from 'vue';
 
 import StackedVirtualSidebarContainer from 'dive-common/components/StackedVirtualSidebarContainer.vue';
@@ -70,6 +71,7 @@ export default defineComponent({
     const cameraStore = useCameraStore();
     const selectedTrackIdRef = useSelectedTrackId();
     const systemHandler = useHandler();
+    const panelExpanded: Ref<Record<string, number | undefined>> = ref({});
 
     const title = computed(() => configMan.configuration.value?.customUI?.title || 'Custom Actions');
     const information = computed(() => configMan.configuration.value?.customUI?.information || []);
@@ -125,6 +127,8 @@ export default defineComponent({
       }
       if (shortcut.type === 'dialog') {
         handler = async () => {
+          const value = getAttributeValue(attribute.name, attribute.belongs, !!attribute.user) as string | number | boolean | undefined;
+          console.log(`Input Value: ${value}`);
           const val = await inputValue({
             title: `Set ${attribute.name} Value`,
             text: attribute.values ? 'Press Spacebar to choose a selection, then Enter to select' : 'Set the Attribute Value below',
@@ -134,6 +138,7 @@ export default defineComponent({
             valueType: attribute.datatype,
             valueList: attribute.values,
             lockedValueList: !!attribute.lockedValues,
+            value,
           });
           if (val !== null) {
             updateAttribute({
@@ -160,11 +165,11 @@ export default defineComponent({
                 prependIcon: shortcut.button.iconPrepend,
                 appendIcon: shortcut.button.iconAppend,
                 buttonToolTip: shortcut.button.buttonToolTip,
-                action: createShortcutHandler(shortcut, attribute),
                 displayValue: shortcut.button.displayValue,
                 attrName: attribute.name,
                 type: attribute.belongs,
                 userAttribute: !!attribute.user,
+                action: createShortcutHandler(shortcut, attribute),
               });
             }
           });
@@ -213,6 +218,7 @@ export default defineComponent({
       }
       return null;
     });
+
     const selectedAttributes = computed(() => {
       if (selectedTrack.value && selectedTrack.value.revision.value) {
         const t = selectedTrack.value;
@@ -223,7 +229,8 @@ export default defineComponent({
       }
       return { trackAttributes: {}, detectionAttributes: {} };
     });
-    const getAttributeValue = (key: string, type: Attribute['belongs'], userAttr: boolean) => {
+
+    const getAttributeValue = (key: string, type: Attribute['belongs'], userAttr: boolean) : string | number | boolean | unknown => {
       const attributes = type === 'detection' ? selectedAttributes.value.detectionAttributes : selectedAttributes.value.trackAttributes;
       if (userAttr && attributes?.userAttributes) {
         const user = store.state.User.user?.login;
@@ -236,6 +243,29 @@ export default defineComponent({
       return '';
     };
 
+    const buttonValueMap = computed(() => {
+      const buttonMapping: Record<string, {attribute: string, button: string; value: string | boolean | number | unknown; length: number }> = {};
+      attributeButtons.value.forEach((attribute) => attribute.buttons.forEach((button) => {
+        if (button.displayValue) {
+          const val = getAttributeValue(button.attrName, button.type, button.userAttribute);
+          buttonMapping[button.attrName] = {
+            attribute: attribute.name, button: button.attrName, value: val, length: val ? (val as string | boolean | number).toString()?.length : 0,
+          };
+        }
+      }));
+      return buttonMapping;
+    });
+
+    const expandPanel = (buttonName: string) => {
+      console.log(`Expand Panel: ${buttonName}`);
+      if (panelExpanded.value[buttonName] !== undefined) {
+        panelExpanded.value[buttonName] = undefined;
+      } else {
+        panelExpanded.value[buttonName] = 0;
+      }
+      panelExpanded.value = { ...panelExpanded.value };
+    };
+
     return {
       attributes,
       title,
@@ -245,6 +275,9 @@ export default defineComponent({
       actionButtons,
       selectedTrackIdRef,
       getAttributeValue,
+      buttonValueMap,
+      panelExpanded,
+      expandPanel,
 
     };
   },
@@ -330,9 +363,21 @@ export default defineComponent({
                 </template>
                 <span>{{ button.buttonToolTip }}</span>
               </v-tooltip>
-              <span v-if="button.displayValue">
-                {{ getAttributeValue(button.attrName, button.type, button.userAttribute) }}
+            </v-col>
+          </v-row>
+          <v-row v-if="buttonValueMap[attribute.name]" class="pa-2">
+            <v-col cols="12">
+              <span v-if="buttonValueMap[attribute.name].length < 50">
+                {{ buttonValueMap[attribute.name].value }}
               </span>
+              <v-expansion-panels v-else :value="panelExpanded[attribute.name]">
+                <v-expansion-panel class="border" @change="expandPanel(attribute.name)">
+                  <v-expansion-panel-header>{{ attribute.name }} Value</v-expansion-panel-header>
+                  <v-expansion-panel-content>
+                    {{ buttonValueMap[attribute.name].value }}
+                  </v-expansion-panel-content>
+                </v-expansion-panel>
+              </v-expansion-panels>
             </v-col>
           </v-row>
         </v-row>

--- a/client/dive-common/components/SidebarContext.vue
+++ b/client/dive-common/components/SidebarContext.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { computed, defineComponent } from 'vue';
+import {
+  computed, defineComponent, ref, watch,
+} from 'vue';
 import context from 'dive-common/store/context';
 import { useConfiguration } from 'vue-media-annotator/provides';
 import { UISettingsKey } from 'vue-media-annotator/ConfigurationManager';
@@ -11,7 +13,7 @@ export default defineComponent({
       default: 300,
     },
   },
-  setup() {
+  setup(props) {
     const configMan = useConfiguration();
     const getUISetting = (key: UISettingsKey) => (configMan.getUISetting(key));
 
@@ -19,7 +21,13 @@ export default defineComponent({
       text: entry.description,
       value,
     })));
-    return { context, options, getUISetting };
+    const updatedWidth = ref(context.state.width || props.width);
+    watch(() => context.state.width, () => {
+      updatedWidth.value = context.state.width || props.width;
+    });
+    return {
+      context, options, getUISetting, updatedWidth,
+    };
   },
 });
 </script>
@@ -28,7 +36,7 @@ export default defineComponent({
   <div>
     <v-card
       v-if="context.state.active !== null"
-      :width="context.state.width || width"
+      :width="updatedWidth"
       tile
       outlined
       class="d-flex flex-column sidebar"

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -865,10 +865,12 @@ export default defineComponent({
     loadData();
     const reloadAnnotations = async () => {
       progress.loaded = false;
-      mediaControllerClear();
-      cameraStore.clearAll();
-      discardChanges();
-      await loadData();
+      nextTick(async () => {
+        mediaControllerClear();
+        cameraStore.clearAll();
+        discardChanges();
+        await loadData();
+      });
     };
     const uiNotification = useUINotifications({
       prompt, handler, aggregateController, reloadAnnotations, datasetId,

--- a/client/dive-common/store/context.ts
+++ b/client/dive-common/store/context.ts
@@ -26,6 +26,7 @@ const state: ContextState = reactive({
   last: 'TypeThreshold',
   active: null,
   subCategory: null,
+  width: 300,
 });
 
 const componentMap: Record<string, ComponentMapItem> = {
@@ -141,6 +142,11 @@ function openClose(active: string, action: boolean, subCategory?: string) {
   window.dispatchEvent(new Event('resize'));
 }
 
+function nudgeWidth(width: number) {
+  state.width = width;
+  window.dispatchEvent(new Event('resize'));
+}
+
 export default {
   toggle,
   openClose,
@@ -148,6 +154,7 @@ export default {
   unregister,
   getComponents,
   resetActive,
+  nudgeWidth,
   componentMap,
   state,
 };

--- a/client/dive-common/vue-utilities/prompt-service/Prompt.vue
+++ b/client/dive-common/vue-utilities/prompt-service/Prompt.vue
@@ -122,8 +122,8 @@ export default defineComponent({
       functions,
       value,
       valueType,
-      valueList,
       lockedValueList,
+      valueList,
       clickPositive,
       clickNegative,
       select,
@@ -173,6 +173,13 @@ export default defineComponent({
             outlined
             autofocus
           />
+          <v-textarea
+            v-else-if="valueType === 'text' && (!valueList || !lockedValueList) && value ? value?.toString().length > 50 : false"
+            ref="input"
+            v-model="value"
+            autofocus
+          />
+
           <v-text-field
             v-else-if="valueType === 'text' && (!valueList || !lockedValueList)"
             ref="input"

--- a/client/dive-common/vue-utilities/prompt-service/index.ts
+++ b/client/dive-common/vue-utilities/prompt-service/index.ts
@@ -15,6 +15,7 @@ export interface PromptParams {
   confirm?: boolean;
   lockedValueList?: boolean;
   allowNullValueList?: boolean;
+  value?: string | number | boolean;
 }
 
 class PromptService {
@@ -38,6 +39,7 @@ class PromptService {
     valueList?: string[],
     lockedValueList?: boolean,
     allowNullValueList?: boolean,
+    value?: string | number | boolean,
   ): void {
     this.component.title = title;
     this.component.text = text;
@@ -51,6 +53,7 @@ class PromptService {
     this.component.valueList = valueList;
     this.component.lockedValueList = lockedValueList;
     this.component.allowNullValueList = allowNullValueList;
+    this.component.value = value;
   }
 
   show({
@@ -82,6 +85,7 @@ class PromptService {
     valueList = undefined,
     lockedValueList = true,
     allowNullValueList = true,
+    value = undefined,
   }: PromptParams): Promise<boolean | number | string | null> {
     return new Promise<boolean | number | string | null>((resolve) => {
       if (!this.component.show) {
@@ -96,6 +100,7 @@ class PromptService {
           valueList,
           lockedValueList,
           allowNullValueList,
+          value,
         );
         return this.component.value;
       }

--- a/client/src/components/LayerManager.vue
+++ b/client/src/components/LayerManager.vue
@@ -133,7 +133,7 @@ export default defineComponent({
       const g = parseInt(hexColor.slice(3, 5), 16);
       const b = parseInt(hexColor.slice(5, 7), 16);
       const colorString = `rgb(${r}, ${g}, ${b})`;
-      maskFilters.value[trackId] = colorString;
+      maskFilters.value = { ...maskFilters.value, [trackId]: colorString };
       return maskFilters.value[trackId];
     };
     if (props.overlays && props.overlays.length) {
@@ -259,6 +259,9 @@ export default defineComponent({
       }
       currentFrameIds.forEach(
         (trackId: AnnotationId) => {
+          if (trackStore?.annotationIds.value.length === 0) {
+            return; // No annotations so just skip the updating
+          }
           const track = trackStore?.get(trackId);
           if (track === undefined) {
             // Track may be located in another Camera
@@ -663,7 +666,7 @@ export default defineComponent({
       height="0"
       style="position: absolute; top: -1px; left: -1px"
     >
-      <defs v-for="(maskFilter, key) in maskFilters" :key="key">
+      <defs v-for="(maskFilter, key) in maskFilters" :key="`mask-filter-key-${key}`">
         <filter :id="`mask-filter-${key}`" color-interpolation-filters="sRGB">
           <!-- Create a mask of where the color is exactly white -->
           <feColorMatrix

--- a/client/src/components/controls/AttributeSwimlaneGraph.vue
+++ b/client/src/components/controls/AttributeSwimlaneGraph.vue
@@ -279,11 +279,13 @@ export default defineComponent({
       const frameAtCursor = x.value.invert(offsetX);
 
       hoveredZone.value = null;
-      // eslint-disable-next-line no-restricted-syntax
-      for (const zone of interactiveZones.value) {
-        if (frameAtCursor >= zone.start && frameAtCursor <= zone.end) {
-          hoveredZone.value = zone.frame;
-          break;
+      if (showSymbols.value) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const zone of interactiveZones.value) {
+          if (frameAtCursor >= zone.start && frameAtCursor <= zone.end) {
+            hoveredZone.value = zone.frame;
+            break;
+          }
         }
       }
     };
@@ -298,7 +300,7 @@ export default defineComponent({
       if (hoverTrack.value !== null) {
         emit('select-track', hoverTrack.value);
       }
-      if (hoveredZone.value !== null) {
+      if (showSymbols.value && hoveredZone.value !== null) {
         e.preventDefault();
         e.stopPropagation();
         mediaController.seek(hoveredZone.value);
@@ -367,7 +369,7 @@ export default defineComponent({
       <canvas ref="canvas" @mousemove="mousemove" @mouseout="mouseout" @mousedown="mousedown" />
     </div>
     <v-card
-      v-if="tooltipComputed && (tooltipComputed.subDisplay?.length ? tooltipComputed.subDisplay.length < 50 : true)"
+      v-if="tooltipComputed && (typeof (tooltipComputed.subDisplay) === 'string' && tooltipComputed.subDisplay.length ? tooltipComputed.subDisplay.length < 50 : true)"
       class="tooltip"
       :style="tooltipComputed.style"
       outlined

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -313,7 +313,7 @@ export default {
   .work-area {
     flex: 1;
     position: relative;
-    overflow: hidden;
+    overflow: visible;
 
     .hand {
       position: absolute;

--- a/dive-dsa-slicer/vue-girder-slicer-ui/package.json
+++ b/dive-dsa-slicer/vue-girder-slicer-ui/package.json
@@ -4,7 +4,7 @@
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "files": [
     "dist",

--- a/dive-dsa-slicer/vue-girder-slicer-ui/src/components/GirderSlicerTaskCard.tw.vue
+++ b/dive-dsa-slicer/vue-girder-slicer-ui/src/components/GirderSlicerTaskCard.tw.vue
@@ -121,7 +121,6 @@ export default defineComponent({
         } else {
           const resp = await slicerApi.runTask(result.value, props.taskId);
           if (resp) {
-            console.log(resp);
             jobData.value = resp;
             emit('run-task', jobData.value);
           }

--- a/dive-dsa-slicer/vue-girder-slicer-ui/src/components/Parameters/BaseParameter.tw.vue
+++ b/dive-dsa-slicer/vue-girder-slicer-ui/src/components/Parameters/BaseParameter.tw.vue
@@ -17,9 +17,9 @@ export default defineComponent({
     const currentValue: Ref<XMLBaseValue> = ref(0);
     onMounted(() => {
         if (props.data.defaultValue && Array.isArray(props.data.defaultValue)) {
-            currentValue.value = props.data.defaultValue.join(',') || props.data.value || '';
+            currentValue.value = props.data.defaultValue.join(',') ?? props.data.value ?? '';
         } else {
-            currentValue.value = props.data.defaultValue || props.data.value || '';
+            currentValue.value = props.data.defaultValue ?? props.data.value ?? '';
         }
     })
     const validate = (e: Event) => {


### PR DESCRIPTION
resolves #245 

- Attribute symbols have  a state for the frame being aligned with the value
- Attribute symbols have a hover state and a range that is equal to 3% of the total number of frames visible in the timeline at the current zoom level and adjusts if there are attributes that are close to each other
- Clicking on this new hover state will jump to the attribute value directly with set text
- Hover state for attribute swimlanes has been updated to render differently for longer text values as a single card instead of colors
- BaseUI now has some styling improvements for displaying texst values
- If text values are longer they are placed in a collapsable field that will maintain open/closed states while scrubbing through other values.