### PR TITLE
transfer config fixes

### DIFF
--- a/client/dive-common/components/configurationEditors/generalConfiguration.vue
+++ b/client/dive-common/components/configurationEditors/generalConfiguration.vue
@@ -101,8 +101,8 @@ export default defineComponent({
     const transferProgress = ref(false);
     const transferConfig = () => {
       transferProgress.value = true;
-      if (configMan.hierarchy.value?.length && baseConfiguration.value) {
-        configMan.transferConfiguration(configMan.hierarchy.value[0].id, baseConfiguration.value);
+      if (originalConfiguration.baseConfiguration && baseConfiguration.value) {
+        configMan.transferConfiguration(originalConfiguration.baseConfiguration, baseConfiguration.value);
       }
       transferProgress.value = false;
     };

--- a/client/dive-common/components/configurationEditors/generalConfiguration.vue
+++ b/client/dive-common/components/configurationEditors/generalConfiguration.vue
@@ -118,6 +118,7 @@ export default defineComponent({
       generalDialog,
       hierarchy: configMan.hierarchy,
       baseConfiguration,
+      originalConfiguration,
       disableConfigurationEditing,
       mergeType,
       mergeSelection,
@@ -217,7 +218,7 @@ export default defineComponent({
           <v-row>
             <v-btn
               :disabled="
-                baseConfiguration === 'null' || (hierarchy && hierarchy[0].id === baseConfiguration)"
+                baseConfiguration === 'null' || (originalConfiguration.baseConfiguration === baseConfiguration)"
               color="warning"
               @click="transferConfig"
             >

--- a/client/dive-common/components/configurationEditors/generalConfiguration.vue
+++ b/client/dive-common/components/configurationEditors/generalConfiguration.vue
@@ -53,6 +53,18 @@ export default defineComponent({
       configurationMerge: mergeType.value,
       disableConfigurationEditing: disableConfigurationEditing.value,
     };
+    const currentConfigName = ref('unknown');
+    const calculateConfigName = () => {
+      if (configMan.hierarchy.value) {
+        const origIndex = configMan.hierarchy.value.findIndex((item) => item.id === originalConfiguration.baseConfiguration);
+        if (origIndex !== -1) {
+          currentConfigName.value = configMan.hierarchy.value[origIndex].name;
+          return;
+        }
+      }
+      currentConfigName.value = 'unknown';
+    };
+    calculateConfigName();
 
     const saveChanges = async () => {
       // We need to take the new values and set them on the 'general' settings
@@ -103,6 +115,8 @@ export default defineComponent({
       transferProgress.value = true;
       if (originalConfiguration.baseConfiguration && baseConfiguration.value) {
         configMan.transferConfiguration(originalConfiguration.baseConfiguration, baseConfiguration.value);
+        originalConfiguration.baseConfiguration = baseConfiguration.value;
+        calculateConfigName();
       }
       transferProgress.value = false;
     };
@@ -120,6 +134,7 @@ export default defineComponent({
       baseConfiguration,
       originalConfiguration,
       disableConfigurationEditing,
+      currentConfigName,
       mergeType,
       mergeSelection,
       launchEditor,
@@ -180,6 +195,9 @@ export default defineComponent({
               timeline and configuration will be saved.
               The list is a folder hierarchy.
             </p>
+            <div class="mb-4">
+              <span>Current Config:</span> <span class="ml-2"><b>{{ currentConfigName }}</b></span>
+            </div>
             <v-select
               v-model="baseConfiguration"
               :items="hierarchy"

--- a/client/dive-common/use/useSave.ts
+++ b/client/dive-common/use/useSave.ts
@@ -130,15 +130,15 @@ export default function useSave(
       //   confidenceFilters: datasetMeta?.confidenceFilters,
       // };
       // promiseList.push(saveStyling(configurationId.value, stylingData));
-      // if (pendingChangeMap.timelineUpsert.size || pendingChangeMap.timelineDelete.size) {
-      //   promiseList.push(saveTimelines(configurationId.value, {
-      //     upsert: Array.from(pendingChangeMap.timelineUpsert).map((pair) => pair[1]),
-      //     delete: Array.from(pendingChangeMap.timelineDelete),
-      //   }).then(() => {
-      //     pendingChangeMap.timelineUpsert.clear();
-      //     pendingChangeMap.timelineDelete.clear();
-      //   }));
-      // }
+      if (pendingChangeMap.timelineUpsert.size || pendingChangeMap.timelineDelete.size) {
+        promiseList.push(saveTimelines(configurationId.value, {
+          upsert: Array.from(pendingChangeMap.timelineUpsert).map((pair) => pair[1]),
+          delete: Array.from(pendingChangeMap.timelineDelete),
+        }).then(() => {
+          pendingChangeMap.timelineUpsert.clear();
+          pendingChangeMap.timelineDelete.clear();
+        }));
+      }
       if (pendingChangeMap.swimlaneUpsert.size || pendingChangeMap.swimlaneDelete.size) {
         promiseList.push(saveSwimlanes(configurationId.value, {
           upsert: Array.from(pendingChangeMap.swimlaneUpsert).map((pair) => pair[1]),

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.11.7",
+  "version": "1.11.8",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"


### PR DESCRIPTION
resolves #273 or part of it

A previous update removed the 'timelines' from being properly set during saving.  This reverts that previous change so timelines can now be properly saved.

The previous transfer configuration tool for the hierarchy made an assumption that the base configuration was in the DatasetId always.  So it would always attempt to transfer that configuration.  Even if it was located somewhere else in the hierarchy (like 2 or 3 folders up).  So clicking on the transfer button would copy the current Dataset Configuration always instead of the loaded configurations.  The "Transfer To Folder" button would always utilize the loaded configuration.  I've updated the code to hopefully make it so it always copies over the loaded configuration and not the base Dataset Config

Added some visibility to the current configuration in the configuration setting dialog (it will now show the current config)