### PR TITLE
bulk metadata update REST endpoint

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.11.10",
+  "version": "1.11.11",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"

--- a/client/platform/web-girder/api/divemetadata.service.ts
+++ b/client/platform/web-girder/api/divemetadata.service.ts
@@ -135,14 +135,14 @@ function deleteDiveMetadataKey(rootMetadataFolder:string, key: string, removeVal
   });
 }
 
-function deleteDiveDatasetMetadataKey(diveDatasetId: string, key: string) {
-  return girderRest.delete(`dive_metadata/${diveDatasetId}`, { params: { key } });
+function deleteDiveDatasetMetadataKey(diveDatasetId: string, rootId: string, key: string) {
+  return girderRest.delete(`dive_metadata/${diveDatasetId}`, { params: { key, rootId } });
 }
-function setDiveDatasetMetadataKey(diveDatasetId: string, key: string, updateValue?: number | string | boolean) {
+function setDiveDatasetMetadataKey(diveDatasetId: string, rootId: string, key: string, updateValue?: number | string | boolean) {
   const value = updateValue === undefined ? null : updateValue;
   return girderRest.patch(`dive_metadata/${diveDatasetId}`, null, {
     params: {
-      key, value,
+      key, value, rootId,
     },
   });
 }

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataSearch.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataSearch.vue
@@ -165,7 +165,7 @@ export default defineComponent({
 
     const updateDiveMetadataKeyVal = async (id: string, key: string, val: boolean | number | string) => {
       try {
-        await setDiveDatasetMetadataKey(id, key, val);
+        await setDiveDatasetMetadataKey(id, props.id, key, val);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (err: any) {
         prompt.prompt({

--- a/dive-dsa-slicer/example-docker-containers/MultipleFullFrameMetadata/MultipleFullFrameMetadata.py
+++ b/dive-dsa-slicer/example-docker-containers/MultipleFullFrameMetadata/MultipleFullFrameMetadata.py
@@ -134,7 +134,7 @@ def process_metadata(args, gc: girder_client.GirderClient):
             print(diveMetadataFilter)
             gc.put(f'/folder/{DIVEMetadataRoot}/metadata', json={'DIVEMetadataFilter': diveMetadataFilter})
     # Now we set the actual value to the system
-    gc.patch(f'dive_metadata/{DIVEDatasetId}', {"key": MetadataKey, "value": MetadataValue})
+    gc.patch(f'dive_metadata/{DIVEDatasetId}', {"key": MetadataKey, "value": MetadataValue, "rootId": DIVEMetadataRoot})
 
 def main(args):
 

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,16 @@
+*.json
+*.csv
+*.xml
+*.yaml
+*.yml
+*.txt
+*.log
+*.md
+*.DS_Store
+*.swp
+*.bak
+*.tmp
+*.log
+*.pid
+*.pid.lock
+*.db    

--- a/scripts/metadata/metadataUpdater.py
+++ b/scripts/metadata/metadataUpdater.py
@@ -1,0 +1,88 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "click",
+#     "Faker",
+# ]
+# ///
+import json
+import random
+import click
+from faker import Faker
+from pathlib import Path
+
+fake = Faker()
+
+
+# Mapping of type to faker function
+FAKER_TYPE_MAP = {
+    "name": lambda: fake.name(),
+    "first_name": lambda: fake.first_name(),
+    "last_name": lambda: fake.last_name(),
+    "address": lambda: fake.street_address(),
+    "city": lambda: fake.city(),
+    "state": lambda: fake.state_abbr(),
+    "zip": lambda: fake.zipcode(),
+    "email": lambda: fake.email(),
+    "phone": lambda: fake.phone_number(),
+    "number": lambda min_val, max_val: random.randint(min_val, max_val),
+    "float": lambda min_val, max_val: round(random.uniform(min_val, max_val), 2),
+    "word": lambda: fake.word(),
+    "date": lambda: fake.date(),
+}
+
+
+@click.command()
+@click.argument("input_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--output-dir", "-o", default="output", type=click.Path(file_okay=False, path_type=Path), help="Directory to write output files")
+@click.option("--new-key", "-k", required=True, help="Key to add to each metadata object")
+@click.option("--type", "value_type", required=True, type=click.Choice(list(FAKER_TYPE_MAP.keys())), help="Type of fake data to generate")
+@click.option("--min", "min_val", default=0, type=int, help="Min value for number/float types")
+@click.option("--max", "max_val", default=100, type=int, help="Max value for number/float types")
+def generate_bulk_metadata(input_file, output_dir, new_key, value_type, min_val, max_val):
+    """
+    Analyze a JSON file of metadata objects and create two JSON outputs:
+    one with matchers by DIVEDataset, and one with matchers by Filename.
+    """
+    with input_file.open() as f:
+        data = json.load(f)
+
+    matcher_by_dataset = []
+    matcher_by_filename = []
+
+    for item in data:
+        if value_type in {"number", "float"}:
+            value = FAKER_TYPE_MAP[value_type](min_val, max_val)
+        else:
+            value = FAKER_TYPE_MAP[value_type]()
+
+        metadata = {new_key: value}
+
+        if "DIVEDataset" in item:
+            matcher_by_dataset.append({
+                "matcher": {"datasetId": item["DIVEDataset"]},
+                "metadata": metadata
+            })
+        if "Filename" in item:
+            matcher_by_filename.append({
+                "matcher": {"videoName": item["Filename"]},
+                "metadata": metadata
+            })
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_path = output_dir / "bulk_update_by_dataset.json"
+    filename_path = output_dir / "bulk_update_by_filename.json"
+
+    with dataset_path.open("w") as f:
+        json.dump(matcher_by_dataset, f, indent=2)
+
+    with filename_path.open("w") as f:
+        json.dump(matcher_by_filename, f, indent=2)
+
+    click.echo(f"✅ Generated {len(matcher_by_dataset)} entries using DIVEDataset → {dataset_path}")
+    click.echo(f"✅ Generated {len(matcher_by_filename)} entries using Filename → {filename_path}")
+
+
+if __name__ == "__main__":
+    generate_bulk_metadata()

--- a/server/dive_server/views_metadata.py
+++ b/server/dive_server/views_metadata.py
@@ -1240,7 +1240,7 @@ class DIVEMetadata(Resource):
         )
         # Helper to infer type/category
         new_keys = {}
-        for idx, entry in enumerate(updates):
+        for _idx, entry in enumerate(updates):
             metadata = entry.get("metadata", {})
             for key, value in metadata.items():
                 if key not in metadata_keys_doc["metadataKeys"]:
@@ -1267,8 +1267,8 @@ class DIVEMetadata(Resource):
                     "min": min(values),
                     "max": max(values),
                 }
-            DIVE_MetadataKeys().addKey(rootFolder, user, key, info, unlocked=True)
-        for idx, entry in enumerate(updates):
+            DIVE_MetadataKeys().addKey(rootFolder, user, key, info, unlocked=False)
+        for _idx, entry in enumerate(updates):
             matcher = entry.get("matcher", {})
             metadata = entry.get("metadata", {})
             reason = None

--- a/server/dive_utils/metadata/models.py
+++ b/server/dive_utils/metadata/models.py
@@ -80,7 +80,6 @@ class DIVE_Metadata(Model):
         )
         if not metadataKeys:
             raise Exception(f'Could not find the root metadataKeys with folderId: {folder["_id"]}')
-        print(f'MetdataKeysOwner: {metadataKeys["owner"]} Owner: {str(owner["_id"])}')
         if (
             key not in metadataKeys['unlocked'] and metadataKeys['owner'] != str(owner['_id'])
         ) and force is False:


### PR DESCRIPTION
resolves #274 

- Adds new endpoint that takes in a JSON strucutre for bulk updating of metadta
- Updates PATH/DELETE endpoints for individual metadata items to include the rootId.  Before it was based just on the DIVEDataset which could cause issues when there were multiple DIVE Metadata folders that utilized the same DIVE Dataset.
    - Updated the client endpoints as well as slicer-cli endpoints for PATH/DELETE of metadata items.
- New endpoint /dive_metadata/bulk_update_metadata/{rootFolder} that takes in a rootFolder Id and a JSON format of objects that contain a 'matcher' object that has either 'datasetId' or 'videoName' and is used to match data.  Then it includes a 'metadata' object where the key/value pairs are updated and added to the matching item.

