### PR TITLE
Dive Metadata to Dive Dataset Connection

### DIFF
--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -293,6 +293,7 @@ export default defineComponent({
       selectedKey,
       selectedCamera,
       editingTrack,
+      diveMetadataRootId,
     } = useModeManager({
       recipes,
       trackFilterControls: trackFilters,
@@ -856,6 +857,7 @@ export default defineComponent({
           mediaLoaded,
           handler.trackSelect,
           aggregateController.value.seek,
+          handler.setDiveMetadataRootId,
         );
         if (!getUISetting('UIContextBarDefaultNotOpen')) {
           context.toggle();
@@ -980,6 +982,7 @@ export default defineComponent({
         visibleModes,
         readOnlyMode: readonlyState,
         imageEnhancements,
+        diveMetadataRootId,
         masks: { getMask, editorFunctions, editorOptions },
       },
       globalHandler,

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -19,6 +19,7 @@ import { clientSettings } from 'dive-common/store/settings';
 import GroupFilterControls from 'vue-media-annotator/GroupFilterControls';
 import CameraStore from 'vue-media-annotator/CameraStore';
 import { CreateFullFrameTrackAction, CreateTrackAction, DIVEAction } from 'dive-common/use/useActions';
+import { setDiveDatasetMetadataKey } from 'platform/web-girder/api/divemetadata.service';
 
 type SupportedFeature = GeoJSON.Feature<GeoJSON.Point | GeoJSON.Polygon | GeoJSON.LineString>;
 
@@ -107,6 +108,8 @@ export default function useModeManager({
   // Track Multi-select state
   const multiSelectList = ref([] as AnnotationId[]);
   const multiSelectActive = computed(() => multiSelectList.value.length > 0);
+
+  const diveMetadataRootId: Ref<string | null> = ref(null);
 
   const _filteredTracks = computed(
     () => trackFilterControls.filteredAnnotations.value.map((filtered) => filtered.annotation),
@@ -941,6 +944,18 @@ export default function useModeManager({
     }
   }
 
+  function setDiveMetadataRootId(id: string | null) {
+    diveMetadataRootId.value = id;
+  }
+
+  async function setMetadataKeyValue(datasetId: string, key: string, value: string) {
+    if (diveMetadataRootId.value === null) {
+      console.error('Dive metadata root ID is not set');
+    }
+
+    return setDiveDatasetMetadataKey(datasetId, key, value);
+  }
+
   return {
     selectedTrackId,
     editingGroupId,
@@ -956,6 +971,7 @@ export default function useModeManager({
     selectedFeatureHandle,
     selectedKey,
     selectedCamera,
+    diveMetadataRootId,
     selectNextTrack,
     handler: {
       commitMerge: handleCommitMerge,
@@ -983,7 +999,8 @@ export default function useModeManager({
       addFullFrameTrack,
       seekFrame,
       toggleKeyFrame,
-
+      setMetadataKeyValue,
+      setDiveMetadataRootId,
     },
   };
 }

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataSearch.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataSearch.vue
@@ -246,7 +246,7 @@ export default defineComponent({
               x-small
               color="primary"
               depressed
-              :to="{ name: 'viewer', params: { id: item.DIVEDataset } }"
+              :to="{ name: 'viewer', params: { id: item.DIVEDataset }, query: { diveMetadataRootId: id } }"
             >
               Launch Annotator
             </v-btn>

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -128,6 +128,9 @@ type ReadOnylModeType = Readonly<Ref<boolean>>;
 const ImageEnhancementsSymbol = Symbol('imageEnhancements');
 type ImageEnhancementsType = Readonly<Ref<ImageEnhancements>>;
 
+const DiveMetadataRootIdSymbol = Symbol('diveMetadataRootId');
+type DiveMetadataRootIdType = Readonly<Ref<string | null>>;
+
 /** Class-based symbols */
 const CameraStoreSymbol = Symbol('cameraStore');
 
@@ -219,6 +222,8 @@ export interface Handler {
     shorcut?: boolean, data?: {frame?: number; selectedTrack?: number}, user?: string): void;
   seekFrame(frame: number): void;
   toggleKeyFrame(selectedTrack?: number): void;
+  setDiveMetadataRootId(id: string | null): void;
+  setMetadataKeyValue(datasetId: string, key: string, value: string): void;
 }
 const HandlerSymbol = Symbol('handler');
 
@@ -261,6 +266,8 @@ function dummyHandler(handle: (name: string, args: unknown[]) => void): Handler 
     processAction(...args) { handle('processAction', args); },
     seekFrame(...args) { handle('seekFrame', args); },
     toggleKeyFrame(...args) { handle('toggleKeyFrame', args); },
+    setDiveMetadataRootId(...args) { handle('setDiveMetadataRootId', args); },
+    setMetadataKeyValue(...args) { handle('setMetadataKeyValue', args); },
   };
 }
 
@@ -297,6 +304,7 @@ export interface State {
   visibleModes: VisibleModesType;
   readOnlyMode: ReadOnylModeType;
   imageEnhancements: ImageEnhancementsType;
+  diveMetadataRootId: DiveMetadataRootIdType;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -393,6 +401,7 @@ function dummyState(): State {
     visibleModes: ref(['rectangle', 'text'] as VisibleAnnotationTypes[]),
     readOnlyMode: ref(false),
     imageEnhancements: ref({}),
+    diveMetadataRootId: ref(null),
   };
 }
 
@@ -557,6 +566,10 @@ function useImageEnhancements() {
   return use<ImageEnhancementsType>(ImageEnhancementsSymbol);
 }
 
+function useDiveMetadataRootId() {
+  return use<DiveMetadataRootIdType>(DiveMetadataRootIdSymbol);
+}
+
 export {
   dummyHandler,
   dummyState,
@@ -580,6 +593,7 @@ export {
   useTrackFilters,
   useTrackStyleManager,
   useSelectedCamera,
+  useDiveMetadataRootId,
   useSelectedKey,
   useSelectedTrackId,
   useEditingGroupId,

--- a/client/src/use/useURLParameters.ts
+++ b/client/src/use/useURLParameters.ts
@@ -7,11 +7,13 @@ export default function useURLParameters(
   mediaLoaded: Ref<boolean>,
   selectTrack: (trackId: AnnotationId | null, edit: boolean) => void,
   seek: (frame: number) => void,
+  setDiveMetadataRootId: (diveMetadataRootId: string | null) => void,
 ) {
   const enableParams = ref(true);
   const setEnableURLParams = (val: boolean) => {
     enableParams.value = val;
   };
+  const localDiveMetadataRootId: Ref<string | null> = ref(null);
   watch([selectedTrackId, frame], () => {
     // update query parameters based on this value
     if (!enableParams.value) {
@@ -23,6 +25,9 @@ export default function useURLParameters(
     }
     if (frame.value !== 0) {
       values.push(`frame=${frame.value}`);
+    }
+    if (localDiveMetadataRootId.value !== null) {
+      values.push(`diveMetadataRootId=${localDiveMetadataRootId.value}`);
     }
     const currentLocation = window.location.href;
     if (values.length === 0) {
@@ -62,6 +67,11 @@ export default function useURLParameters(
         if (!Number.isNaN(urlFrame)) {
           seek(urlFrame);
         }
+      }
+      if (paramMapping.diveMetadataRootId !== undefined) {
+        const { diveMetadataRootId } = paramMapping;
+        setDiveMetadataRootId(diveMetadataRootId);
+        localDiveMetadataRootId.value = diveMetadataRootId;
       }
     }
   };


### PR DESCRIPTION
resolves #295 

- Adds a new query Parameter `diveMetadataRootId` that is added when launching from a DIVE Metadata viewer
- useModeManager will allow you to set the global value for diveMetadataRootId which can be imported using `useDiveMetadataRootId` so it can be used in other components.


TODO:

- [ ] Make it so the save button when it detects tat diveMetadataRootId is not null it will set a 'lastModified' value to the time of the last modification and it will also set a 'lastModifiedUser' to the email address of the lastModifiedUser.