### PR TITLE
implement metadata importing

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dive-dsa",
-  "version": "1.11.14",
+  "version": "1.11.15",
   "author": {
     "name": "Kitware, Inc.",
     "email": "Bryon.Lewis@kitware.com"

--- a/client/platform/web-girder/api/divemetadata.service.ts
+++ b/client/platform/web-girder/api/divemetadata.service.ts
@@ -206,15 +206,15 @@ async function putDiveMetadataLastModified(folderId:string, rootId: string) {
   return girderRest.put(`dive_metadata/${folderId}/last_modified`, null, { params: { rootId } });
 }
 
-async function processImportedFile(rootId:string) {
-  return girderRest.post(`dive_metadata/bulk_update_file/${rootId}`);
+async function processImportedFile(rootId:string, replace = false) {
+  return girderRest.post(`dive_metadata/bulk_update_file/${rootId}`, null, { params: { replace } });
 }
 
 interface HTMLFile extends File {
   webkitRelativePath?: string;
 }
 
-async function importMetadataFile(parentId: string, path: string, file?: HTMLFile) {
+async function importMetadataFile(parentId: string, path: string, file?: HTMLFile, replace = false) {
   if (file === undefined) {
     return false;
   }
@@ -236,7 +236,7 @@ async function importMetadataFile(parentId: string, path: string, file?: HTMLFil
       headers: { 'Content-Type': 'application/octet-stream' },
     });
     if (uploadResponse.status === 200) {
-      const final = await processImportedFile(parentId);
+      const final = await processImportedFile(parentId, replace);
       return final.status === 200;
     }
   }

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataFilter.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataFilter.vue
@@ -11,11 +11,12 @@ import DIVEMetadataFilterItemVue from './DIVEMetadataFilterItem.vue';
 import DIVEMetadataCloneVue from './DIVEMetadataClone.vue';
 import DIVEMetadataSlicerVue from './DIVEMetadataSlicer.vue';
 import DIVEMetadataExportVue from './DIVEMetadataExport.vue';
+import DIVEMetadataImportVue from './DIVEMetadataImport.vue';
 
 export default defineComponent({
   name: 'DIVEMetadataFilter',
   components: {
-    DIVEMetadataFilterItemVue, DIVEMetadataCloneVue, DIVEMetadataSlicerVue, DIVEMetadataExportVue,
+    DIVEMetadataFilterItemVue, DIVEMetadataCloneVue, DIVEMetadataSlicerVue, DIVEMetadataExportVue, DIVEMetadataImportVue,
   },
   props: {
     currentPage: {
@@ -264,6 +265,10 @@ export default defineComponent({
       return false;
     });
 
+    const metadataImported = () => {
+      emit('update:currentPage', 0);
+    };
+
     return {
 
       pageList,
@@ -286,6 +291,7 @@ export default defineComponent({
       toggleRegex,
       regEx,
       showSlicerCLI,
+      metadataImported,
     };
   },
 });
@@ -332,6 +338,7 @@ export default defineComponent({
 
         <v-spacer />
         <DIVEMetadataSlicerVue v-if="showSlicerCLI" :filters="currentFilter" :metadata-root="id" class="pr-2" @job-complete="jobCompleted()" />
+        <DIVEMetadataImportVue :metadata-root="id" class="pr-2" @updated="metadataImported()" />
         <DIVEMetadataExportVue :metadata-root="id" :filters="currentFilter" class="pr-4" />
         <v-chip><span class="pr-1">Filtered:</span>{{ filtered }} / {{ count }}</v-chip>
         <v-select

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataFilter.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataFilter.vue
@@ -337,8 +337,8 @@ export default defineComponent({
         </v-btn>
 
         <v-spacer />
-        <DIVEMetadataSlicerVue v-if="showSlicerCLI" :filters="currentFilter" :metadata-root="id" class="pr-2" @job-complete="jobCompleted()" />
-        <DIVEMetadataImportVue :metadata-root="id" class="pr-2" @updated="metadataImported()" />
+        <DIVEMetadataSlicerVue v-if="showSlicerCLI" :filters="currentFilter" :metadata-root="id" class="mr-2" @job-complete="jobCompleted()" />
+        <DIVEMetadataImportVue v-if="ownerAdmin" :metadata-root="id" class="mr-2" @updated="metadataImported()" />
         <DIVEMetadataExportVue :metadata-root="id" :filters="currentFilter" class="pr-4" />
         <v-chip><span class="pr-1">Filtered:</span>{{ filtered }} / {{ count }}</v-chip>
         <v-select

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataImport.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataImport.vue
@@ -98,7 +98,7 @@ export default defineComponent({
       <v-tooltip bottom>
         <template #activator="{ on: tooltipOn }">
           <v-btn
-            class="ma-0"
+            class="ma-0 mx-2"
             v-bind="buttonOptions"
             :disabled="processing"
             v-on="{ ...tooltipOn, ...menuOn }"
@@ -131,7 +131,9 @@ export default defineComponent({
           <ul>
             <li> Metadata JSON </li>
             <li> Metadata NDJSON </li>
+            <li> Metadata CSV </li>
           </ul>
+          <p>The Import matching requires that either the key/column 'DIVEDataset' or 'Filename' is present.  If there are multiple 'Filename' matches in the DIVEMetadata it will then rely on the field 'DIVE_Path' to match the path.</p>
         </v-card-text>
         <v-container>
           <v-col>

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataImport.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataImport.vue
@@ -35,8 +35,7 @@ export default defineComponent({
     const { prompt } = usePrompt();
     const processing = ref(false);
     const menuOpen = ref(false);
-    const additive = ref(false);
-    const additivePrepend = ref('');
+    const replace = ref(false);
     const openUpload = async () => {
       try {
         const ret = await openFromDisk('annotation');
@@ -50,12 +49,14 @@ export default defineComponent({
               props.metadataRoot,
               path,
               ret.fileList[0],
+              replace.value,
             );
           } else {
             importFile = await importMetadataFile(
               props.metadataRoot,
               path,
               undefined,
+              replace.value,
             );
           }
           if (importFile) {
@@ -78,8 +79,7 @@ export default defineComponent({
       openUpload,
       processing,
       menuOpen,
-      additive,
-      additivePrepend,
+      replace,
 
     };
   },
@@ -134,6 +134,13 @@ export default defineComponent({
             <li> Metadata CSV </li>
           </ul>
           <p>The Import matching requires that either the key/column 'DIVEDataset' or 'Filename' is present.  If there are multiple 'Filename' matches in the DIVEMetadata it will then rely on the field 'DIVE_Path' to match the path.</p>
+          <v-card-actions>
+            <v-checkbox
+              v-model="replace"
+              label="Replace existing metadata"
+              :disabled="processing || readOnlyMode"
+            />
+          </v-card-actions>
         </v-card-text>
         <v-container>
           <v-col>

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataImport.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataImport.vue
@@ -1,0 +1,153 @@
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { useApi } from 'dive-common/apispec';
+import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
+import { getResponseError } from 'vue-media-annotator/utils';
+import { importMetadataFile } from 'platform/web-girder/api/divemetadata.service';
+
+export default defineComponent({
+  name: 'DIVEMetadataImport',
+  props: {
+    metadataRoot: {
+      type: String,
+      default: null,
+    },
+    blockOnUnsaved: {
+      type: Boolean,
+      default: false,
+    },
+    buttonOptions: {
+      type: Object,
+      default: () => ({}),
+    },
+    menuOptions: {
+      type: Object,
+      default: () => ({}),
+    },
+    readOnlyMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['updated'],
+  setup(props, { emit }) {
+    const { openFromDisk } = useApi();
+    const { prompt } = usePrompt();
+    const processing = ref(false);
+    const menuOpen = ref(false);
+    const additive = ref(false);
+    const additivePrepend = ref('');
+    const openUpload = async () => {
+      try {
+        const ret = await openFromDisk('annotation');
+        if (!ret.canceled) {
+          menuOpen.value = false;
+          const path = ret.filePaths[0];
+          let importFile = false;
+          processing.value = true;
+          if (ret.fileList?.length) {
+            importFile = await importMetadataFile(
+              props.metadataRoot,
+              path,
+              ret.fileList[0],
+            );
+          } else {
+            importFile = await importMetadataFile(
+              props.metadataRoot,
+              path,
+              undefined,
+            );
+          }
+          if (importFile) {
+            processing.value = false;
+            emit('updated');
+          }
+        }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        const text = [getResponseError(error)];
+        prompt({
+          title: 'Import Failed',
+          text,
+          positiveButton: 'OK',
+        });
+        processing.value = false;
+      }
+    };
+    return {
+      openUpload,
+      processing,
+      menuOpen,
+      additive,
+      additivePrepend,
+
+    };
+  },
+});
+</script>
+
+<template>
+  <v-menu
+    v-model="menuOpen"
+    :close-on-content-click="false"
+    :nudge-width="120"
+    v-bind="menuOptions"
+    max-width="280"
+  >
+    <template #activator="{ on: menuOn }">
+      <v-tooltip bottom>
+        <template #activator="{ on: tooltipOn }">
+          <v-btn
+            class="ma-0"
+            v-bind="buttonOptions"
+            :disabled="processing"
+            v-on="{ ...tooltipOn, ...menuOn }"
+          >
+            <div>
+              <v-icon>
+                {{ processing ? 'mdi-spin mdi-sync' : 'mdi-application-import' }}
+              </v-icon>
+              <span
+                v-show=" buttonOptions.block"
+                class="pl-1"
+              >
+                Import
+              </span>
+            </div>
+          </v-btn>
+        </template>
+        <span>Import Metadata</span>
+      </v-tooltip>
+    </template>
+    <template>
+      <v-card
+        outlined
+      >
+        <v-card-title>
+          Import Formats
+        </v-card-title>
+        <v-card-text>
+          Multiple Data types can be imported:
+          <ul>
+            <li> Metadata JSON </li>
+            <li> Metadata NDJSON </li>
+          </ul>
+        </v-card-text>
+        <v-container>
+          <v-col>
+            <v-row>
+              <v-btn
+                depressed
+                block
+                :disabled="processing"
+                @click="openUpload"
+              >
+                Import
+              </v-btn>
+            </v-row>
+          </v-col>
+        </v-container>
+      </v-card>
+    </template>
+  </v-menu>
+</template>

--- a/docs/DIVE-Metadata.md
+++ b/docs/DIVE-Metadata.md
@@ -191,3 +191,41 @@ Content-Type: application/json
 | `key` | Query Parameter | The metadata key to remove. |
 | `removeValues` | Query Parameter | Whether to remove all associated values from datasets (true/false). |
 
+
+## Bulk Updating DIVE Metadata
+
+There are two endpoitns that can be used to bulk update DIVE Metadata.  One is a direct Endpoint that takes in JSON data:
+
+**POST** `/dive_metadata/bulk_update_metadata/{rootId}`
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rootId` | Path Parameter | The root metadata folder ID. |
+| `updates` | Body Parameter | An array of metadata key/value pairs to update |
+
+This system requires that either `DIVEDataset` or `Filename` be in each object to match up the correct Metadata Item.  Additionally if there are multiple `Filename` matches within the dataset it requires that `DIVE_Path` also be included in upload.  It will attempt to use `DIVEDataset` first followed by `Filename` and `DIVE_Path`.
+This creates a Folder within the Root folder called `DIVEMetadataHistory` that will create a backup of the current metadata each time it is updated using this endpoint.
+
+### Example
+
+```json
+{
+  "DIVEDataset": "68b833ac1394856d5124dbbf",
+  "Filename": "VideoFile.mp4",
+  "VideoCategory": "sample",
+  "VideoRating": 5,
+}
+```
+
+## Bulk Update File Upload
+
+In addition to the Direct POSTing of JSON metadata there is another endpoint that will process an uploaded folder in the RootId.
+
+**POST** `/dive_metadata/bulk_update_file/{rootId}`
+
+Once a file is uploaded to the DIVEMetadata Root Folder hitting this endpoint will process this file to update the metadata.
+Similar to the JSON format this file can be either JSON, NDJSON or CSV.  With CSV it requires columns that have `DIVEDataset`, `Filename`, `DIVE_Path` if required.
+Similar to the POST endpoint with JSON this creates a Folder within the Root folder called `DIVEMetadataHistory` that will create a backup of the current metadata each time it is updated using this endpoint.
+

--- a/server/dive_utils/constants.py
+++ b/server/dive_utils/constants.py
@@ -90,6 +90,7 @@ OverlayVideoItemMarker = "overlayVideoItem"
 OverlayMetadataMarker = "overlayMetadata"
 DIVEMetadataMarker = "DIVEMetadata"
 DIVEMetadataFilter = "DIVEMetadataFilter"
+DIVEMetadataHistoryMarker = "DIVEMetadataHistory"
 DIVEMetadataClonedFilter = "DIVEMetadataClonedFilter"
 DIVEMetadataClonedFilterBase = "DIVEMetadataClonedFilterBase"
 # Other constants

--- a/server/dive_utils/metadata/models.py
+++ b/server/dive_utils/metadata/models.py
@@ -95,7 +95,7 @@ class DIVE_Metadata(Model):
     def deleteKey(self, folder, root, owner, key):
         existing = self.findOne({'DIVEDataset': str(folder['_id'])})
         if not existing:
-            raise Exception(f'Note MetadataKeys with folderId: {folder["_id"]} found')
+            raise Exception(f'Note MetadataKeys with folderId: {folder["_id"]} not found')
         query = {'root': existing['root']}
         metadataKeys = DIVE_MetadataKeys().findOne(
             query=query,
@@ -106,6 +106,22 @@ class DIVE_Metadata(Model):
         if existing['metadata'].get(key, None) is not None:
             del existing['metadata'][key]
             self.save(existing)
+
+    def removeCustomKeys(self, folder, root, owner):
+        existing = self.findOne({'DIVEDataset': str(folder['_id'])})
+        if not existing:
+            raise Exception(f'Note MetadataKeys with folderId: {folder["_id"]} not found')
+        query = {'root': existing['root']}
+        metadataKeys = DIVE_MetadataKeys().findOne(
+            query=query,
+            owner=str(owner['_id']),
+        )
+        if not metadataKeys:
+            raise Exception(f'Could not find the root metadataKeys with folderId: {folder["_id"]}')
+        keys_to_remove = [key for key in existing['metadata'].keys() if key not in ['LastModifiedTime', 'LastModifiedBy', 'DIVEDataset', 'filename', 'DIVE_Path'] and not key.startswith('DIVE_') and not key.startswith('ffprobe')]
+        for key in keys_to_remove:
+            del existing['metadata'][key]
+        self.save(existing)
 
     def deleteKeys(self, root, owner, key):
         existing = self.find({'root': str(root['_id'])})
@@ -264,6 +280,21 @@ class DIVE_MetadataKeys(Model):
                 self.save(existing)
             else:
                 raise Exception(f'Key: {key} not found in the current metdata')
+
+    def removeCustomKeys(self, folderId, owner):
+        existing = self.findOne({'root': str(folderId)})
+        if not existing:
+            raise Exception(f'Note MetadataKeys with folderId: {folderId} not found')
+        if owner['_id'] and existing['owner'] != str(owner['_id']):
+            raise Exception('Only the Owner can modify key permissions')
+        elif existing:
+            keys_to_remove = [key for key in existing['metadataKeys'].keys() if key not in ['LastModifiedTime', 'LastModifiedBy', 'DIVEDataset', 'filename', 'DIVE_Path'] and not key.startswith('DIVE_') and not key.startswith('ffprobe')]
+            for key in keys_to_remove:
+                if key in existing['unlocked']:
+                    existing['unlocked'].remove(key)
+                if key in existing['metadataKeys'].keys():
+                    del existing['metadataKeys'][key]
+            self.save(existing)
 
     def updateKeyValue(self, folderId, owner, key, value, categoricalLimit):
         existing = self.findOne({'root': folderId})

--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -2455,10 +2455,10 @@ files = [
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
+    {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\""},
+    {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.23.5", markers = "python_version == \"3.11\""},
-    {version = ">=1.21.4", markers = "python_version == \"3.10\" and platform_system == \"Darwin\""},
-    {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version == \"3.10\""},
 ]
 
 [[package]]
@@ -2480,10 +2480,10 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
     {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
     {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\""},
+    {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 
 [[package]]
@@ -2509,6 +2509,93 @@ files = [
     {file = "palettable-3.3.3-py2.py3-none-any.whl", hash = "sha256:74e9e7d7fe5a9be065e02397558ed1777b2df0b793a6f4ce1a5ee74f74fb0caa"},
     {file = "palettable-3.3.3.tar.gz", hash = "sha256:094dd7d9a5fc1cca4854773e5c1fc6a315b33bd5b3a8f47064928facaf0490a8"},
 ]
+
+[[package]]
+name = "pandas"
+version = "2.3.2"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pandas-2.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52bc29a946304c360561974c6542d1dd628ddafa69134a7131fdfd6a5d7a1a35"},
+    {file = "pandas-2.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:220cc5c35ffaa764dd5bb17cf42df283b5cb7fdf49e10a7b053a06c9cb48ee2b"},
+    {file = "pandas-2.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c05e15111221384019897df20c6fe893b2f697d03c811ee67ec9e0bb5a3424"},
+    {file = "pandas-2.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc03acc273c5515ab69f898df99d9d4f12c4d70dbfc24c3acc6203751d0804cf"},
+    {file = "pandas-2.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d25c20a03e8870f6339bcf67281b946bd20b86f1a544ebbebb87e66a8d642cba"},
+    {file = "pandas-2.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:21bb612d148bb5860b7eb2c10faacf1a810799245afd342cf297d7551513fbb6"},
+    {file = "pandas-2.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:b62d586eb25cb8cb70a5746a378fc3194cb7f11ea77170d59f889f5dfe3cec7a"},
+    {file = "pandas-2.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1333e9c299adcbb68ee89a9bb568fc3f20f9cbb419f1dd5225071e6cddb2a743"},
+    {file = "pandas-2.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:76972bcbd7de8e91ad5f0ca884a9f2c477a2125354af624e022c49e5bd0dfff4"},
+    {file = "pandas-2.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b98bdd7c456a05eef7cd21fd6b29e3ca243591fe531c62be94a2cc987efb5ac2"},
+    {file = "pandas-2.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1d81573b3f7db40d020983f78721e9bfc425f411e616ef019a10ebf597aedb2e"},
+    {file = "pandas-2.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e190b738675a73b581736cc8ec71ae113d6c3768d0bd18bffa5b9a0927b0b6ea"},
+    {file = "pandas-2.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c253828cb08f47488d60f43c5fc95114c771bbfff085da54bfc79cb4f9e3a372"},
+    {file = "pandas-2.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:9467697b8083f9667b212633ad6aa4ab32436dcbaf4cd57325debb0ddef2012f"},
+    {file = "pandas-2.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fbb977f802156e7a3f829e9d1d5398f6192375a3e2d1a9ee0803e35fe70a2b9"},
+    {file = "pandas-2.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b9b52693123dd234b7c985c68b709b0b009f4521000d0525f2b95c22f15944b"},
+    {file = "pandas-2.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bd281310d4f412733f319a5bc552f86d62cddc5f51d2e392c8787335c994175"},
+    {file = "pandas-2.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96d31a6b4354e3b9b8a2c848af75d31da390657e3ac6f30c05c82068b9ed79b9"},
+    {file = "pandas-2.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:df4df0b9d02bb873a106971bb85d448378ef14b86ba96f035f50bbd3688456b4"},
+    {file = "pandas-2.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:213a5adf93d020b74327cb2c1b842884dbdd37f895f42dcc2f09d451d949f811"},
+    {file = "pandas-2.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:8c13b81a9347eb8c7548f53fd9a4f08d4dfe996836543f805c987bafa03317ae"},
+    {file = "pandas-2.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0c6ecbac99a354a051ef21c5307601093cb9e0f4b1855984a084bfec9302699e"},
+    {file = "pandas-2.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c6f048aa0fd080d6a06cc7e7537c09b53be6642d330ac6f54a600c3ace857ee9"},
+    {file = "pandas-2.3.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0064187b80a5be6f2f9c9d6bdde29372468751dfa89f4211a3c5871854cfbf7a"},
+    {file = "pandas-2.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ac8c320bded4718b298281339c1a50fb00a6ba78cb2a63521c39bec95b0209b"},
+    {file = "pandas-2.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:114c2fe4f4328cf98ce5716d1532f3ab79c5919f95a9cfee81d9140064a2e4d6"},
+    {file = "pandas-2.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:48fa91c4dfb3b2b9bfdb5c24cd3567575f4e13f9636810462ffed8925352be5a"},
+    {file = "pandas-2.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:12d039facec710f7ba305786837d0225a3444af7bbd9c15c32ca2d40d157ed8b"},
+    {file = "pandas-2.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c624b615ce97864eb588779ed4046186f967374185c047070545253a52ab2d57"},
+    {file = "pandas-2.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0cee69d583b9b128823d9514171cabb6861e09409af805b54459bd0c821a35c2"},
+    {file = "pandas-2.3.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2319656ed81124982900b4c37f0e0c58c015af9a7bbc62342ba5ad07ace82ba9"},
+    {file = "pandas-2.3.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b37205ad6f00d52f16b6d09f406434ba928c1a1966e2771006a9033c736d30d2"},
+    {file = "pandas-2.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:837248b4fc3a9b83b9c6214699a13f069dc13510a6a6d7f9ba33145d2841a012"},
+    {file = "pandas-2.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d2c3554bd31b731cd6490d94a28f3abb8dd770634a9e06eb6d2911b9827db370"},
+    {file = "pandas-2.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:88080a0ff8a55eac9c84e3ff3c7665b3b5476c6fbc484775ca1910ce1c3e0b87"},
+    {file = "pandas-2.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d4a558c7620340a0931828d8065688b3cc5b4c8eb674bcaf33d18ff4a6870b4a"},
+    {file = "pandas-2.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45178cf09d1858a1509dc73ec261bf5b25a625a389b65be2e47b559905f0ab6a"},
+    {file = "pandas-2.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77cefe00e1b210f9c76c697fedd8fdb8d3dd86563e9c8adc9fa72b90f5e9e4c2"},
+    {file = "pandas-2.3.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:13bd629c653856f00c53dc495191baa59bcafbbf54860a46ecc50d3a88421a96"},
+    {file = "pandas-2.3.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:36d627906fd44b5fd63c943264e11e96e923f8de77d6016dc2f667b9ad193438"},
+    {file = "pandas-2.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:a9d7ec92d71a420185dec44909c32e9a362248c4ae2238234b76d5be37f208cc"},
+    {file = "pandas-2.3.2.tar.gz", hash = "sha256:ab7b58f8f82706890924ccdfb5f48002b83d2b5a3845976a9fb705d36c34dcdb"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.7"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
+aws = ["s3fs (>=2022.11.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
+compression = ["zstandard (>=0.19.0)"]
+computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
+feather = ["pyarrow (>=10.0.1)"]
+fss = ["fsspec (>=2022.11.0)"]
+gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
+hdf5 = ["tables (>=3.8.0)"]
+html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
+mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=10.0.1)"]
+performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
+plot = ["matplotlib (>=3.6.3)"]
+postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
+pyarrow = ["pyarrow (>=10.0.1)"]
+spss = ["pyreadstat (>=1.2.0)"]
+sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "passlib"
@@ -4234,4 +4321,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<=3.12"
-content-hash = "a761332bb2b61c308ccf1ea1d5c19b1431b2bcb62b2c93097c128039544f3b48"
+content-hash = "25a6b1daf1de9a875e8ad4b6ec7286dc5a78c1fe3669651533b7870929b4543b"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -69,6 +69,7 @@ numpy = "^1.21.4"
 torch = "^2.7.1"
 sam2 = "^1.1.0"
 opencv-python-headless = "^4.11.0.86"
+pandas = "^2.3.2"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
resolves #302 

- Add component for metadata import within the DIVE Viewer
- Backend logic for data importer that supports new structure
- Creates backups in folder called `DIVEMetadataHistory` for each time data is imported and adjusted
- Has the option to import CSV, JSON or NDJSON files.
- Requires either a `DIVEDataset` field or a `Filename` and `DIVE_Path` field for matching the filename with the metadata field.
- Defaults to additive mode, but can be imported with replacement mode as well
- Updated Documentation to explain formats and the endpoints.
