### PR TITLE
Post Process Batch Job

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -102,7 +102,7 @@ The client is broken into 4 main folders which separate different parts of the s
 
 ## Unified API Specification
 
-To resuse as much code as possible between the Desktop and Web versions there is a unified API which provides the capability to export/import/save/delete annotations and metadata as well as run training and configuration pipelines.  This API allows both versions to share the `/dive-common` and `/src` folders while handling these calls differently.
+To reuse as much code as possible between the Desktop and Web versions there is a unified API which provides the capability to export/import/save/delete annotations and metadata as well as run training and configuration pipelines.  This API allows both versions to share the `/dive-common` and `/src` folders while handling these calls differently.
 
 ## Annotation Viewer Organization
 

--- a/client/platform/web-girder/views/Admin/AdminJobs.vue
+++ b/client/platform/web-girder/views/Admin/AdminJobs.vue
@@ -55,7 +55,7 @@ export default defineComponent({
     const initTypes = async () => {
       const typesAndStatus = (await getJobTypesStatus());
       jobTypes.value = typesAndStatus.data.types;
-      filterTypes.value = ['convert', 'Dive Metadata Slicer CLI Batch', 'slicer_cli_web_job', 'Slicer CLI Metadata Run'];
+      filterTypes.value = ['convert', 'Dive Metadata Slicer CLI Batch', 'slicer_cli_web_job', 'Slicer CLI Metadata Run', 'DIVE Batch Postprocess'];
     };
     const getData = async () => {
       const statusNums = filterStatus.value.map(

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -202,7 +202,7 @@ def postprocess(
     additive=False,
     additivePrepend='',
     logic='replace',
-) -> types.GirderModel:
+) -> dict:
     """
     Post-processing to be run after media/annotation import
 
@@ -214,11 +214,17 @@ def postprocess(
 
     In either case, the following may run synchronously:
         Conversion of CSV annotations into track JSON
+
+    Returns:
+        dict: Contains 'folder' (the processed folder) and 'job_ids' (list of created job IDs)
     """
     job_is_private = user.get(constants.UserPrivateQueueEnabledMarker, False)
     isClone = dsFolder.get(constants.ForeignMediaIdMarker, None) is not None
     # add default confidence filter threshold to folder metadata
     dsFolder['meta'][constants.ConfidenceFiltersMarker] = {'default': 0.1}
+    
+    # Track job IDs for batch processing
+    created_job_ids = []
 
     # Validate user-supplied metadata fields are present
     if fromMeta(dsFolder, constants.FPSMarker) is None:
@@ -255,7 +261,8 @@ def postprocess(
             newjob.job[constants.JOBCONST_DATASET_ID] = str(item["folderId"])
             newjob.job[constants.JOBCONST_CREATOR] = str(user['_id'])
             Job().save(newjob.job)
-            return dsFolder
+            created_job_ids.append(newjob.job['_id'])
+            return {'folder': dsFolder, 'job_ids': created_job_ids}
 
         if not isClone:
             # transcode VIDEO if necessary
@@ -281,6 +288,7 @@ def postprocess(
                 newjob.job[constants.JOBCONST_PRIVATE_QUEUE] = job_is_private
                 newjob.job[constants.JOBCONST_DATASET_ID] = dsFolder["_id"]
                 Job().save(newjob.job)
+                created_job_ids.append(newjob.job['_id'])
 
             # transcode IMAGERY if necessary
             imageItems = Folder().childItems(
@@ -305,6 +313,7 @@ def postprocess(
                 newjob.job[constants.JOBCONST_PRIVATE_QUEUE] = job_is_private
                 newjob.job[constants.JOBCONST_DATASET_ID] = dsFolder["_id"]
                 Job().save(newjob.job)
+                created_job_ids.append(newjob.job['_id'])
 
             elif imageItems.count() > 0:
                 dsFolder["meta"][constants.DatasetMarker] = True
@@ -312,4 +321,4 @@ def postprocess(
             Folder().save(dsFolder)
     print(f'Processing Items: {user}')
     process_items(dsFolder, user, additive, additivePrepend)
-    return dsFolder
+    return {'folder': dsFolder, 'job_ids': created_job_ids}

--- a/server/dive_server/crud_rpc.py
+++ b/server/dive_server/crud_rpc.py
@@ -222,7 +222,7 @@ def postprocess(
     isClone = dsFolder.get(constants.ForeignMediaIdMarker, None) is not None
     # add default confidence filter threshold to folder metadata
     dsFolder['meta'][constants.ConfidenceFiltersMarker] = {'default': 0.1}
-    
+
     # Track job IDs for batch processing
     created_job_ids = []
 

--- a/server/dive_server/event.py
+++ b/server/dive_server/event.py
@@ -1,14 +1,19 @@
 from datetime import datetime, timedelta
 import os
+import cherrypy
 
 from bson.objectid import ObjectId
 from girder import logger
 from girder.models.folder import Folder
 from girder.models.item import Item
 from girder.models.setting import Setting
+from girder.models.token import Token
 from girder.models.user import User
+from girder_jobs.models.job import Job
+from girder.api.rest import getApiUrl
 from girder.settings import SettingKey
 from girder.utility.mail_utils import renderTemplate, sendMail
+from girder_worker.girder_plugin.utils import getWorkerApiUrl
 
 from dive_utils import asbool, fromMeta
 from dive_utils.constants import (
@@ -22,7 +27,7 @@ from dive_utils.constants import (
     videoRegex,
 )
 
-from . import crud_rpc
+from dive_tasks.dive_batch_postprocess import DIVEBatchPostprocessTaskParams
 
 
 def send_new_user_email(event):
@@ -66,11 +71,11 @@ def process_assetstore_import(event, meta: dict):
         userId = parentFolder['creatorId'] or parentFolder['baseParentId']
         user = User().findOne({'_id': ObjectId(userId)})
         foldername = f'Video {item["name"]}'
-        # resuse existing folder if it already exists with same name
+        # reuse existing folder if it already exists with same name
         dest = Folder().createFolder(parentFolder, foldername, creator=user, reuseExisting=True)
         now = datetime.now()
         if now - dest['created'] > timedelta(hours=1):
-            # Remove the old  referenced item, replace it with the new one.
+            # Remove the old referenced item, replace it with the new one.
             oldItem = Item().findOne({'folderId': dest['_id'], 'name': item['name']})
             if oldItem is not None:
                 if oldItem['meta'].get('codec', False):
@@ -108,12 +113,40 @@ def process_assetstore_import(event, meta: dict):
 
 
 def convert_video_recrusive(folder, user):
-    subFolders = list(Folder().childFolders(folder, 'folder', user))
-    for child in subFolders:
-        if child.get('meta', {}).get(MarkForPostProcess, False):
-            Folder().save(child)
-            crud_rpc.postprocess(user, child, False, True)
-        convert_video_recrusive(child, user)
+    """
+    Start a batch postprocess job for all folders with MarkForPostProcess flag.
+    This replaces the manual recursive postprocess calls with a single batch job.
+    """
+    # Create a token for the batch job
+
+    token = Token().createToken(user=user, days=2)
+
+    dive_batch_postprocess_task_params: DIVEBatchPostprocessTaskParams = {
+        "source_folder_id": str(folder['_id']),
+        "skipJobs": False,  # Allow jobs to run (transcoding, etc.)
+        "skipTranscoding": True,  # Skip transcoding if not needed
+        "additive": False,
+        "additivePrepend": '',
+        "userId": str(user['_id']),
+        "girderToken": str(token['_id']),
+        "girderApiUrl": getWorkerApiUrl(),
+    }
+    if not Setting().get('worker.api_url'):
+        Setting().set('worker.api_url', getApiUrl())
+    job = Job().createLocalJob(
+        module='dive_tasks.dive_batch_postprocess',
+        function='batchPostProccessingTaskLauncher',
+        kwargs={'params': dive_batch_postprocess_task_params, 'url': cherrypy.url()},
+        title='Batch process Dive Batch Postprocess',
+        type='DIVE Batch Postprocess',
+        user=user,
+        public=True,
+        asynchronous=True,
+    )
+    job = Job().save(job)
+    Job().scheduleJob(job)
+
+    logger.info(f'Started batch postprocess job {job.job["_id"]} for folder {folder["name"]}')
 
 
 class DIVES3Imports:

--- a/server/dive_server/event.py
+++ b/server/dive_server/event.py
@@ -135,7 +135,7 @@ def convert_video_recrusive(folder, user):
         Setting().set('worker.api_url', getApiUrl())
     job = Job().createLocalJob(
         module='dive_tasks.dive_batch_postprocess',
-        function='batchPostProccessingTaskLauncher',
+        function='batchPostProcessingTaskLauncher',
         kwargs={'params': dive_batch_postprocess_task_params, 'url': cherrypy.url()},
         title='Batch process Dive Batch Postprocess',
         type='DIVE Batch Postprocess',

--- a/server/dive_server/views_rpc.py
+++ b/server/dive_server/views_rpc.py
@@ -96,7 +96,7 @@ class RpcResource(Resource):
         )
     )
     def postprocess(self, folder, skipJobs, skipTranscoding, additive, additivePrepend, logic):
-        return crud_rpc.postprocess(
+        result = crud_rpc.postprocess(
             self.getCurrentUser(),
             folder,
             skipJobs,
@@ -105,6 +105,8 @@ class RpcResource(Resource):
             additivePrepend,
             logic,
         )
+        # Return the folder for backward compatibility, but also include job_ids
+        return result
 
     @access.user
     @autoDescribeRoute(

--- a/server/dive_server/web_client/JobStatus.js
+++ b/server/dive_server/web_client/JobStatus.js
@@ -5,7 +5,7 @@ events.on('g:appload.before', () => {
     const JobStatus = girder.plugins.jobs.JobStatus;
     const jobPluginIsCancelable = JobStatus.isCancelable;
     JobStatus.isCancelable = function (job) {
-        if (job.get('type').startsWith('Dive Metadata Slicer CLI Batch')) {
+        if (job.get('type').startsWith('Dive Metadata Slicer CLI Batch') || job.get('type').startsWith('DIVE Batch Postprocess')) {
             return ![JobStatus.CANCELED, JobStatus.WORKER_CANCELING || 824,
                 JobStatus.SUCCESS, JobStatus.ERROR].includes(job.get('status'));
         }

--- a/server/dive_tasks/__init__.py
+++ b/server/dive_tasks/__init__.py
@@ -24,4 +24,4 @@ class DIVEPlugin(GirderWorkerPluginABC):
     def task_imports(self):
         # Return a list of python importable paths to the
         # plugin's path directory
-        return ["dive_tasks.tasks", "dive_tasks.dive_metadata_slicer_cli", "dive_tasks.sam_tasks"]
+        return ["dive_tasks.tasks", "dive_tasks.dive_metadata_slicer_cli", "dive_tasks.sam_tasks", "dive_tasks.dive_batch_postprocess"]

--- a/server/dive_tasks/__init__.py
+++ b/server/dive_tasks/__init__.py
@@ -24,4 +24,9 @@ class DIVEPlugin(GirderWorkerPluginABC):
     def task_imports(self):
         # Return a list of python importable paths to the
         # plugin's path directory
-        return ["dive_tasks.tasks", "dive_tasks.dive_metadata_slicer_cli", "dive_tasks.sam_tasks", "dive_tasks.dive_batch_postprocess"]
+        return [
+            "dive_tasks.tasks",
+            "dive_tasks.dive_metadata_slicer_cli",
+            "dive_tasks.sam_tasks",
+            "dive_tasks.dive_batch_postprocess",
+        ]

--- a/server/dive_tasks/dive_batch_postprocess.py
+++ b/server/dive_tasks/dive_batch_postprocess.py
@@ -1,13 +1,12 @@
-import threading
 import copy
+import threading
 import time
 from typing import Dict, List, Union
 
 import cherrypy
-
-from girder_client import GirderClient
 from girder.models.token import Token
 from girder.models.user import User
+from girder_client import GirderClient
 from girder_jobs.models.job import Job
 from girder_worker.app import app
 from girder_worker.task import Task
@@ -36,7 +35,6 @@ class DIVEBatchPostprocessTaskParams:
         self.userId = userId
         self.girderToken = girderToken
         self.girderApiUrl = girderApiUrl
-
 
 
 def batch_postprocess_task(baseJob: Task):
@@ -158,7 +156,7 @@ def batch_postprocess_task(baseJob: Task):
                             'skipTranscoding': skipTranscoding,
                             'additive': additive,
                             'additivePrepend': additivePrepend,
-                        }
+                        },
                     )
 
                     # If skipJobs=True, postprocess runs synchronously
@@ -226,6 +224,7 @@ def batch_postprocess_task(baseJob: Task):
         status=JobStatus.SUCCESS,
     )
 
+
 def batchPostProccessingTaskLauncher(job):
     """
     Run a batch of jobs via a thread.
@@ -283,8 +282,6 @@ def batchPostprocessTask(job):
 
     :param job: the job model.
     """
-    proc = threading.Thread(
-        target=batch_postprocess_task, args=(job,), daemon=True
-    )
+    proc = threading.Thread(target=batch_postprocess_task, args=(job,), daemon=True)
     proc.start()
     return job, proc

--- a/server/dive_tasks/dive_batch_postprocess.py
+++ b/server/dive_tasks/dive_batch_postprocess.py
@@ -1,14 +1,11 @@
-import copy
 import threading
 import time
-from typing import Dict, List, Union
+from typing import List
 
-import cherrypy
 from girder.models.token import Token
 from girder.models.user import User
 from girder_client import GirderClient
 from girder_jobs.models.job import Job
-from girder_worker.app import app
 from girder_worker.task import Task
 from girder_worker.utils import JobStatus
 

--- a/server/dive_tasks/dive_batch_postprocess.py
+++ b/server/dive_tasks/dive_batch_postprocess.py
@@ -222,7 +222,7 @@ def batch_postprocess_task(baseJob: Task):
     )
 
 
-def batchPostProccessingTaskLauncher(job):
+def batchPostProcessingTaskLauncher(job):
     """
     Run a batch of jobs via a thread.
 
@@ -271,14 +271,3 @@ def _get_folder_name(gc: GirderClient, folder_id: str) -> str:
         return folder.get('name', folder_id)
     except Exception:
         return folder_id
-
-
-def batchPostprocessTask(job):
-    """
-    Run a batch postprocess task via a thread.
-
-    :param job: the job model.
-    """
-    proc = threading.Thread(target=batch_postprocess_task, args=(job,), daemon=True)
-    proc.start()
-    return job, proc

--- a/server/dive_tasks/dive_batch_postprocess.py
+++ b/server/dive_tasks/dive_batch_postprocess.py
@@ -1,0 +1,290 @@
+import threading
+import copy
+import time
+from typing import Dict, List, Union
+
+import cherrypy
+
+from girder_client import GirderClient
+from girder.models.token import Token
+from girder.models.user import User
+from girder_jobs.models.job import Job
+from girder_worker.app import app
+from girder_worker.task import Task
+from girder_worker.utils import JobStatus
+
+
+class DIVEBatchPostprocessTaskParams:
+    """Describes the parameters for running batch postprocess on folders with MarkForPostProcess flag"""
+
+    def __init__(
+        self,
+        source_folder_id: str,
+        skipJobs: bool,
+        skipTranscoding: bool,
+        additive: bool,
+        additivePrepend: str,
+        userId: str,
+        girderToken: str,
+        girderApiUrl: str,
+    ):
+        self.source_folder_id = source_folder_id
+        self.skipJobs = skipJobs
+        self.skipTranscoding = skipTranscoding
+        self.additive = additive
+        self.additivePrepend = additivePrepend
+        self.userId = userId
+        self.girderToken = girderToken
+        self.girderApiUrl = girderApiUrl
+
+
+
+def batch_postprocess_task(baseJob: Task):
+    """
+    Run batch postprocess on folders with MarkForPostProcess flag.
+
+    :param baseJob: the job model containing the task parameters.
+    """
+    params = baseJob['kwargs']['params']
+
+    source_folder_id = params['source_folder_id']
+    skipJobs = params['skipJobs']
+    skipTranscoding = params['skipTranscoding']
+    additive = params['additive']
+    additivePrepend = params['additivePrepend']
+    userId = params['userId']
+    user = User().load(userId, force=True)
+    token = Token().createToken(user=user)
+
+    # Initialize Girder client
+    gc = GirderClient(apiUrl=params['girderApiUrl'])
+    gc.token = token['_id']
+
+    # Update base job status
+    baseJob = Job().updateJob(
+        baseJob,
+        log='Started DIVE Batch Postprocess processing\n',
+        status=JobStatus.RUNNING,
+    )
+
+    # Find all folders with MarkForPostProcess flag
+    marked_folders = []
+    _find_marked_folders(gc, source_folder_id, marked_folders)
+
+    total_count = len(marked_folders)
+    if total_count == 0:
+        Job().updateJob(
+            baseJob,
+            log='No folders found with MarkForPostProcess flag\n',
+            status=JobStatus.SUCCESS,
+        )
+        return
+
+    Job().updateJob(
+        baseJob,
+        log=f'Found {total_count} folders marked for postprocess\n',
+        progressTotal=total_count,
+        status=JobStatus.RUNNING,
+    )
+
+    # Process folders one by one
+    processed = 0
+    done = False
+    current_job_id = None
+
+    try:
+        while not done:
+            baseJob = Job().load(id=baseJob['_id'], force=True)
+
+            if not baseJob or baseJob['status'] in {
+                JobStatus.CANCELED,
+                JobStatus.ERROR,
+            }:
+                break
+
+            # Check if we have a current job running
+            if current_job_id:
+                try:
+                    current_job = Job().load(current_job_id, force=True)
+                    if current_job and current_job['status'] in {
+                        JobStatus.SUCCESS,
+                        JobStatus.ERROR,
+                        JobStatus.CANCELED,
+                    }:
+                        # Current job finished, move to next
+                        current_job_id = None
+                        processed += 1
+
+                        if current_job['status'] == JobStatus.SUCCESS:
+                            Job().updateJob(
+                                baseJob,
+                                log=f'Completed postprocess for folder {processed} of {total_count}\n',
+                                progressCurrent=processed,
+                                progressTotal=total_count,
+                                status=JobStatus.RUNNING,
+                            )
+                        else:
+                            error_msg = current_job.get("log", "Unknown error")
+                            Job().updateJob(
+                                baseJob,
+                                log=f'Postprocess failed for folder {processed} of {total_count}: {error_msg}\n',
+                                progressCurrent=processed,
+                                progressTotal=total_count,
+                                status=JobStatus.RUNNING,
+                            )
+                except Exception:
+                    # Job might have been deleted or other error, continue
+                    current_job_id = None
+                    processed += 1
+                    Job().updateJob(
+                        baseJob,
+                        log=f'Lost track of job for folder {processed} of {total_count}, continuing...\n',
+                        progressCurrent=processed,
+                        progressTotal=total_count,
+                        status=JobStatus.RUNNING,
+                    )
+
+            # Start next job if we don't have one running and have more to process
+            if not current_job_id and processed < total_count:
+                folder_id = marked_folders[processed]
+                folder_name = _get_folder_name(gc, folder_id)
+
+                try:
+                    # Call postprocess endpoint for this folder
+                    result = gc.post(
+                        f'dive_rpc/postprocess/{folder_id}',
+                        data={
+                            'skipJobs': skipJobs,
+                            'skipTranscoding': skipTranscoding,
+                            'additive': additive,
+                            'additivePrepend': additivePrepend,
+                        }
+                    )
+
+                    # If skipJobs=True, postprocess runs synchronously
+                    if skipJobs:
+                        Job().updateJob(
+                            baseJob,
+                            log=f'Completed postprocess for folder {processed + 1} of {total_count}: {folder_name}\n',
+                            progressCurrent=processed + 1,
+                            progressTotal=total_count,
+                            status=JobStatus.RUNNING,
+                        )
+                        processed += 1
+                    else:
+                        # For async jobs, track the created job IDs
+                        job_ids = result.get('job_ids', [])
+                        if job_ids:
+                            # Track the first job ID (usually the main processing job)
+                            current_job_id = job_ids[0]
+                            Job().updateJob(
+                                baseJob,
+                                log=f'Started postprocess for folder {processed + 1} of {total_count}: {folder_name} (tracking job {current_job_id})\n',
+                                progressCurrent=processed,
+                                progressTotal=total_count,
+                                status=JobStatus.RUNNING,
+                            )
+                        else:
+                            # No jobs created, treat as synchronous
+                            Job().updateJob(
+                                baseJob,
+                                log=f'Completed postprocess for folder {processed + 1} of {total_count}: {folder_name} (no jobs created)\n',
+                                progressCurrent=processed + 1,
+                                progressTotal=total_count,
+                                status=JobStatus.RUNNING,
+                            )
+                            processed += 1
+
+                except Exception as e:
+                    Job().updateJob(
+                        baseJob,
+                        log=f'Error processing folder {folder_name}: {str(e)}\n',
+                        progressCurrent=processed + 1,
+                        progressTotal=total_count,
+                        status=JobStatus.RUNNING,
+                    )
+                    processed += 1  # Continue with next folder
+                    continue
+
+            # Check if we're done
+            if processed >= total_count:
+                done = True
+                break
+
+            time.sleep(0.1)
+
+    except Exception as exc:
+        Job().updateJob(
+            baseJob,
+            log=f'Error During DIVE Batch Postprocess: {str(exc)}\n',
+            status=JobStatus.ERROR,
+        )
+
+    Job().updateJob(
+        baseJob,
+        log=f'Finished DIVE Batch Postprocess: {processed}/{total_count} folders processed\n',
+        status=JobStatus.SUCCESS,
+    )
+
+def batchPostProccessingTaskLauncher(job):
+    """
+    Run a batch of jobs via a thread.
+
+    :param job: the job model.
+    """
+    proc = threading.Thread(target=batch_postprocess_task, args=(job,), daemon=True)
+    proc.start()
+    return job, proc
+
+
+def _find_marked_folders(gc: GirderClient, folder_id: str, marked_folders: List[str]):
+    """
+    Recursively find all child folders with MarkForPostProcess flag.
+
+    :param gc: GirderClient instance
+    :param folder_id: ID of the folder to search
+    :param marked_folders: List to append marked folder IDs to
+    """
+    try:
+        # Get child folders
+        child_folders = gc.listFolder(folder_id, 'folder')
+
+        for child_folder in child_folders:
+            # Check if this folder has MarkForPostProcess flag
+            if child_folder.get('meta', {}).get('MarkForPostProcess', False):
+                marked_folders.append(child_folder['_id'])
+
+            # Recursively search child folders
+            _find_marked_folders(gc, child_folder['_id'], marked_folders)
+
+    except Exception as e:
+        # Log error but continue processing
+        print(f"Error searching folder {folder_id}: {str(e)}")
+
+
+def _get_folder_name(gc: GirderClient, folder_id: str) -> str:
+    """
+    Get the name of a folder by its ID.
+
+    :param gc: GirderClient instance
+    :param folder_id: ID of the folder
+    :return: Folder name or folder_id if name cannot be retrieved
+    """
+    try:
+        folder = gc.getFolder(folder_id)
+        return folder.get('name', folder_id)
+    except Exception:
+        return folder_id
+
+
+def batchPostprocessTask(job):
+    """
+    Run a batch postprocess task via a thread.
+
+    :param job: the job model.
+    """
+    proc = threading.Thread(
+        target=batch_postprocess_task, args=(job,), daemon=True
+    )
+    proc.start()
+    return job, proc

--- a/server/dive_tasks/tasks.py
+++ b/server/dive_tasks/tasks.py
@@ -104,7 +104,6 @@ def convert_video(
             and item['name'].endswith('.mp4')
         ):
             # Now we can update the meta data and push the values
-            manager.updateStatus(JobStatus.PUSHING_OUTPUT)
             gc.addMetadataToItem(
                 itemId,
                 {

--- a/server/dive_utils/metadata/models.py
+++ b/server/dive_utils/metadata/models.py
@@ -118,7 +118,14 @@ class DIVE_Metadata(Model):
         )
         if not metadataKeys:
             raise Exception(f'Could not find the root metadataKeys with folderId: {folder["_id"]}')
-        keys_to_remove = [key for key in existing['metadata'].keys() if key not in ['LastModifiedTime', 'LastModifiedBy', 'DIVEDataset', 'filename', 'DIVE_Path'] and not key.startswith('DIVE_') and not key.startswith('ffprobe')]
+        keys_to_remove = [
+            key
+            for key in existing['metadata'].keys()
+            if key
+            not in ['LastModifiedTime', 'LastModifiedBy', 'DIVEDataset', 'filename', 'DIVE_Path']
+            and not key.startswith('DIVE_')
+            and not key.startswith('ffprobe')
+        ]
         for key in keys_to_remove:
             del existing['metadata'][key]
         self.save(existing)
@@ -288,7 +295,20 @@ class DIVE_MetadataKeys(Model):
         if owner['_id'] and existing['owner'] != str(owner['_id']):
             raise Exception('Only the Owner can modify key permissions')
         elif existing:
-            keys_to_remove = [key for key in existing['metadataKeys'].keys() if key not in ['LastModifiedTime', 'LastModifiedBy', 'DIVEDataset', 'filename', 'DIVE_Path'] and not key.startswith('DIVE_') and not key.startswith('ffprobe')]
+            keys_to_remove = [
+                key
+                for key in existing['metadataKeys'].keys()
+                if key
+                not in [
+                    'LastModifiedTime',
+                    'LastModifiedBy',
+                    'DIVEDataset',
+                    'filename',
+                    'DIVE_Path',
+                ]
+                and not key.startswith('DIVE_')
+                and not key.startswith('ffprobe')
+            ]
             for key in keys_to_remove:
                 if key in existing['unlocked']:
                     existing['unlocked'].remove(key)


### PR DESCRIPTION
resolves #311 

- Creates a single job runner like Slicer CLI to handle postprocessing jobs after import
- Uses this new runner to kick of jobs sequentially
- Updated to handle direct importing into collections.
- Updates to add the cancellation functionality to the main process task
