### PR TITLE
Segment Sizing

### DIFF
--- a/client/dive-common/components/Attributes/AttributeShortcuts.vue
+++ b/client/dive-common/components/Attributes/AttributeShortcuts.vue
@@ -6,7 +6,7 @@ import {
 import { AttributeShortcut, ButtonShortcut } from 'vue-media-annotator/use/AttributeTypes';
 import usedShortcuts from 'dive-common/use/usedShortcuts';
 import { useAttributes } from 'vue-media-annotator/provides';
-import { uniq } from 'lodash';
+import { max, uniq } from 'lodash';
 import ButtonShortcutEditor from '../CustomUI/ButtonShortcutEditor.vue';
 
 export default defineComponent({
@@ -217,6 +217,9 @@ export default defineComponent({
       }
       if ((newVal === 'frames' || newVal === 'seconds') && segmentSize.value < 1) {
         segmentSize.value = 1;
+      }
+      if (newVal === 'percent' && segmentSize.value >= 1) {
+        segmentSize.value = 0.99;
       }
     });
 
@@ -430,6 +433,7 @@ awaitingKeyPress
               v-model.number="segmentSize"
               type="number"
               :step="segmentSizeType === 'percent' ? 0.01 : 1"
+              :max="segmentSizeType === 'percent' ? 1 : undefined"
               :min="segmentSizeType === 'percent' ? 0.01 : 1"
               label="Segment Size"
               class="mr-4"

--- a/client/dive-common/components/Attributes/AttributeShortcuts.vue
+++ b/client/dive-common/components/Attributes/AttributeShortcuts.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import {
   computed, defineComponent, ref, PropType, Ref,
+  watch,
 } from 'vue';
 import { AttributeShortcut, ButtonShortcut } from 'vue-media-annotator/use/AttributeTypes';
 import usedShortcuts from 'dive-common/use/usedShortcuts';
@@ -36,6 +37,8 @@ export default defineComponent({
     const selectedShortcutButton: Ref<ButtonShortcut | undefined> = ref(undefined);
     const isSegment = ref(false);
     const segmentEditable = ref(false);
+    const segmentSize = ref(0.01);
+    const segmentSizeType: Ref<'frames' | 'seconds' | 'percent'> = ref('percent');
     const copy = ref(props.value);
     const awaitingKeyPress = ref(false);
     const shortcutError: Ref<{description: string; type: 'System' | 'Custom'}| null> = ref(null);
@@ -81,6 +84,8 @@ export default defineComponent({
       editShortcutDialog.value = true;
       isSegment.value = shortcut.segment || false;
       segmentEditable.value = !shortcut.segment ? false : shortcut.segmentEditable || false;
+      segmentSize.value = shortcut.segmentSize || 0.01;
+      segmentSizeType.value = shortcut.segmentSizeType || 'percent';
     };
 
     const cancel = () => {
@@ -93,6 +98,8 @@ export default defineComponent({
       selectedShortcutKey.value = '';
       isSegment.value = false;
       segmentEditable.value = false;
+      segmentSize.value = 0.01;
+      segmentSizeType.value = 'percent';
     };
     const save = () => {
       editShortcutDialog.value = false;
@@ -105,6 +112,8 @@ export default defineComponent({
         button: selectedShortcutButton.value,
         segment: isSegment.value || undefined,
         segmentEditable: isSegment.value ? (segmentEditable.value || undefined) : undefined,
+        segmentSize: isSegment.value ? segmentSize.value : undefined,
+        segmentSizeType: isSegment.value ? segmentSizeType.value : undefined,
       };
       selectedShortcutButton.value = undefined;
       emit('input', copy.value);
@@ -202,6 +211,15 @@ export default defineComponent({
       window.document.addEventListener('keydown', handleKeyDown);
     };
 
+    watch(segmentSizeType, (newVal) => {
+      if (newVal === 'percent' && segmentSize.value > 1) {
+        segmentSize.value = 0.01;
+      }
+      if ((newVal === 'frames' || newVal === 'seconds') && segmentSize.value < 1) {
+        segmentSize.value = 1;
+      }
+    });
+
     const selectedDisplayKey = computed(() => {
       let base = '';
       if (selectedShortcutModifiers.value.length) {
@@ -219,6 +237,8 @@ export default defineComponent({
       selectedShortcutButton,
       isSegment,
       segmentEditable,
+      segmentSize,
+      segmentSizeType,
       shortcutTypes,
       selectedDisplayKey,
       awaitingKeyPress,
@@ -405,7 +425,21 @@ awaitingKeyPress
               <span>Allows for editing of an entire segment</span>
             </v-tooltip>
           </v-row>
-
+          <v-row v-if="isSegment">
+            <v-text-field
+              v-model.number="segmentSize"
+              type="number"
+              :step="segmentSizeType === 'percent' ? 0.01 : 1"
+              :min="segmentSizeType === 'percent' ? 0.01 : 1"
+              label="Segment Size"
+              class="mr-4"
+            />
+            <v-select
+              v-model="segmentSizeType"
+              :items="['frames', 'seconds', 'percent']"
+              label="Segment Size Type"
+            />
+          </v-row>
           <button-shortcut-editor
             v-model="selectedShortcutButton"
           />

--- a/client/dive-common/components/Attributes/AttributeShortcuts.vue
+++ b/client/dive-common/components/Attributes/AttributeShortcuts.vue
@@ -6,7 +6,7 @@ import {
 import { AttributeShortcut, ButtonShortcut } from 'vue-media-annotator/use/AttributeTypes';
 import usedShortcuts from 'dive-common/use/usedShortcuts';
 import { useAttributes } from 'vue-media-annotator/provides';
-import { max, uniq } from 'lodash';
+import { uniq } from 'lodash';
 import ButtonShortcutEditor from '../CustomUI/ButtonShortcutEditor.vue';
 
 export default defineComponent({

--- a/client/dive-common/components/CustomUI/CustomUIBase.vue
+++ b/client/dive-common/components/CustomUI/CustomUIBase.vue
@@ -19,19 +19,19 @@ import { StringKeyObject } from 'vue-media-annotator/BaseAnnotation';
 import context from 'dive-common/store/context';
 
 interface AttributeDisplayButton {
-    name: string;
-    color: string;
-    prependIcon?: string;
-    appendIcon?: string;
-    buttonToolTip?: string;
-    displayValue?: boolean;
-    attrName: string;
-    type: Attribute['belongs'];
-    userAttribute: boolean;
-    segment?: boolean;
-    actionType: 'set' | 'remove' | 'dialog';
-    disabled: boolean;
-    action: () => void;
+  name: string;
+  color: string;
+  prependIcon?: string;
+  appendIcon?: string;
+  buttonToolTip?: string;
+  displayValue?: boolean;
+  attrName: string;
+  type: Attribute['belongs'];
+  userAttribute: boolean;
+  segment?: boolean;
+  actionType: 'set' | 'remove' | 'dialog';
+  disabled: boolean;
+  action: () => void;
 }
 
 interface ActionDisplayButton {
@@ -44,11 +44,11 @@ interface ActionDisplayButton {
 }
 
 interface AttributeButtons {
-    name: string;
-    attrName: string;
-    type: 'track' | 'detection';
-    description?: string;
-    buttons: AttributeDisplayButton[];
+  name: string;
+  attrName: string;
+  type: 'track' | 'detection';
+  description?: string;
+  buttons: AttributeDisplayButton[];
 }
 
 type AttributeButtonList = AttributeButtons[];
@@ -72,7 +72,7 @@ export default defineComponent({
     const configMan = useConfiguration();
     const attributes = useAttributes();
     const { inputValue } = usePrompt();
-    const { frame: frameRef } = useTime();
+    const { frame: frameRef, frameRate } = useTime();
     const store = useStore();
     const cameraStore = useCameraStore();
     const selectedTrackIdRef = useSelectedTrackId();
@@ -108,7 +108,22 @@ export default defineComponent({
           if (frameRef.value !== undefined) {
             let inRange = false;
             let varianceRange = false;
-            const segmentCreationFrames = (track.end - track.begin) * trackPercentSize;
+            let segmentCreationFrames = (track.end - track.begin) * trackPercentSize;
+            const { segmentSize, segmentSizeType } = shortcut;
+            if (segmentSize && segmentSizeType) {
+              if (segmentSizeType === 'frames' && segmentSize > 0) {
+                // segment size is in frames
+                segmentCreationFrames = segmentSize;
+              }
+              if (segmentSizeType === 'seconds' && segmentSize > 0 && frameRate.value) {
+                // segment size is in seconds
+                segmentCreationFrames = segmentSize * frameRate.value;
+              }
+              if (segmentSizeType === 'percent' && segmentSize > 0) {
+                // segment size is in percent of track
+                segmentCreationFrames = (track.end - track.begin) * segmentSize;
+              }
+            }
             for (let i = 0; i < ranges.length; i += 2) {
               const start = ranges[i];
               const end = ranges[i + 1];
@@ -119,11 +134,9 @@ export default defineComponent({
               }
               if (frameRef.value < start && frameRef.value > start - segmentCreationFrames) {
                 varianceRange = true;
-                break;
               }
               if (frameRef.value > end && frameRef.value < end + segmentCreationFrames) {
                 varianceRange = true;
-                break;
               }
             }
             if (shortcut.type === 'remove' && !inRange) {
@@ -157,6 +170,121 @@ export default defineComponent({
       }
     }
 
+    const createSegmentHandler = (shortcut: AttributeShortcut, attribute: Attribute, val: number | string | boolean) => {
+      if (selectedTrackIdRef.value === null || frameRef.value === undefined) {
+        return;
+      }
+      const track = cameraStore.getAnyTrack(selectedTrackIdRef.value);
+      // Check if inside segment
+      if (shortcut.segmentEditable) {
+        const rangeVals = track.getFrameAttributeRanges([attribute.name], store.state.User.user?.login || null);
+        const ranges = rangeVals[attribute.name];
+        let insideSegmentBounds: { start: number, end: number } | null = null;
+        if (ranges && ranges.length > 0) {
+          for (let i = 0; i < ranges.length; i += 2) {
+            const startseg = ranges[i];
+            const endseg = ranges[i + 1];
+            if (frameRef.value >= startseg && frameRef.value <= endseg) {
+              insideSegmentBounds = { start: startseg, end: endseg };
+              break;
+            }
+          }
+        }
+        if (insideSegmentBounds) {
+          updateAttribute({
+            name: attribute.name,
+            value: val,
+            belongs: attribute.belongs,
+            frame: insideSegmentBounds.start,
+          });
+          updateAttribute({
+            name: attribute.name,
+            value: val,
+            belongs: attribute.belongs,
+            frame: insideSegmentBounds.end,
+          });
+          return;
+        }
+      }
+      // Create attribute segment if not inside segment and it is editable
+      const frame = frameRef.value;
+      let segmentCreationFrames = (track.end - track.begin) * trackPercentSize;
+      const { segmentSize, segmentSizeType } = shortcut;
+      if (segmentSize && segmentSizeType) {
+        if (segmentSizeType === 'frames' && segmentSize > 0) {
+          // segment size is in frames
+          segmentCreationFrames = segmentSize;
+        }
+        if (segmentSizeType === 'seconds' && segmentSize > 0 && frameRate.value) {
+          // segment size is in seconds
+          segmentCreationFrames = segmentSize * frameRate.value;
+        }
+        if (segmentSizeType === 'percent' && segmentSize > 0) {
+          // segment size is in percent of track
+          segmentCreationFrames = (track.end - track.begin) * segmentSize;
+        }
+      }
+      // Check the ranges so we don't clobber another Segment with our new size:
+      const rangeChecks = track.getFrameAttributeRanges([attribute.name], store.state.User.user?.login || null);
+      const rangesCheck = rangeChecks[attribute.name];
+      let start = Math.max(0, Math.round(frame - (segmentCreationFrames / 2.0)));
+      let end = Math.min(track.end, Math.round(frame + (segmentCreationFrames / 2.0)));
+
+      // We have this new start/End point need to check and see if they intersect any ranges or are larger than a range
+
+      if (rangesCheck && rangesCheck.length > 0) {
+        for (let i = 0; i < rangesCheck.length; i += 2) {
+          const starts = rangesCheck[i];
+          const ends = rangesCheck[i + 1];
+          if ((start >= starts && start <= ends) || (end >= starts && end <= ends)
+            || (start <= starts && end >= ends)) {
+            // intersects se we shrink the segment to 1 frame smaller than the new segments
+            if (start >= starts && start <= ends) {
+              // our start is inside a segment so move it to the end of that segment
+              // but make sure we don't go past the end point
+              const newStart = Math.min(end - 1, ends + 1);
+              if (newStart >= end) {
+                return; // can't make a segment here
+              }
+              start = newStart;
+            } else if (end >= starts && end <= ends) {
+              // our end is inside a segment so move it to the start of that segment
+              // but make sure we don't go before the start point
+              const newEnd = Math.max(start + 1, starts - 1);
+              if (newEnd <= start) {
+                return; // can't make a segment here
+              }
+              end = newEnd;
+            } else if (start <= starts && end >= ends) {
+              // we are larger than an existing segment so just shrink to either side of it
+              if (starts - 1 <= start && ends + 1 >= end) {
+                return; // can't make a segment here
+              }
+              // If the midpoint is to the left of the segment, move the end, else move the start
+              const midPoint = (start + end) / 2.0;
+              if (midPoint < starts) {
+                end = starts - 1;
+              } else {
+                start = starts - 1;
+              }
+            }
+          }
+        }
+      }
+      updateAttribute({
+        name: attribute.name,
+        value: val,
+        belongs: attribute.belongs,
+        frame: start,
+      });
+      updateAttribute({
+        name: attribute.name,
+        value: val,
+        belongs: attribute.belongs,
+        frame: end,
+      });
+    };
+
     const createShortcutHandler = (shortcut: AttributeShortcut, attribute: Attribute) => {
       // eslint-disable-next-line @typescript-eslint/ban-types
       let handler: () => void = () => undefined;
@@ -167,55 +295,8 @@ export default defineComponent({
             val = parseFloat(shortcut.value);
           }
           if (shortcut.segment && selectedTrackIdRef.value !== null && frameRef.value !== undefined) {
-            const track = cameraStore.getAnyTrack(selectedTrackIdRef.value);
-            // Check if inside segment
-            if (shortcut.segmentEditable) {
-              const rangeVals = track.getFrameAttributeRanges([attribute.name], store.state.User.user?.login || null);
-              const ranges = rangeVals[attribute.name];
-              let insideSegmentBounds: { start: number, end: number} | null = null;
-              if (ranges && ranges.length > 0) {
-                for (let i = 0; i < ranges.length; i += 2) {
-                  const startseg = ranges[i];
-                  const endseg = ranges[i + 1];
-                  if (frameRef.value >= startseg && frameRef.value <= endseg) {
-                    insideSegmentBounds = { start: startseg, end: endseg };
-                    break;
-                  }
-                }
-              }
-              if (insideSegmentBounds) {
-                updateAttribute({
-                  name: attribute.name,
-                  value: val,
-                  belongs: attribute.belongs,
-                  frame: insideSegmentBounds.start,
-                });
-                updateAttribute({
-                  name: attribute.name,
-                  value: val,
-                  belongs: attribute.belongs,
-                  frame: insideSegmentBounds.end,
-                });
-                return;
-              }
-            }
-            // Create attribute segment if not inside segment and it is editable
-            const frame = frameRef.value;
-            const segmentCreationFrames = (track.end - track.begin) * trackPercentSize;
-            const start = Math.max(0, Math.round(frame - (segmentCreationFrames / 2.0)));
-            const end = Math.min(track.end, Math.round(frame + (segmentCreationFrames / 2.0)));
-            updateAttribute({
-              name: attribute.name,
-              value: val,
-              belongs: attribute.belongs,
-              frame: start,
-            });
-            updateAttribute({
-              name: attribute.name,
-              value: val,
-              belongs: attribute.belongs,
-              frame: end,
-            });
+            createSegmentHandler(shortcut, attribute, val);
+            updateButtonMap();
             return;
           }
           updateAttribute({
@@ -283,56 +364,7 @@ export default defineComponent({
           });
           if (val !== null) {
             if (shortcut.segment && selectedTrackIdRef.value !== null && frameRef.value !== undefined) {
-              const track = cameraStore.getAnyTrack(selectedTrackIdRef.value);
-              const frame = frameRef.value;
-              // Check if inside segment
-              if (shortcut.segmentEditable) {
-                const rangeVals = track.getFrameAttributeRanges([attribute.name], store.state.User.user?.login || null);
-                const ranges = rangeVals[attribute.name];
-                let insideSegmentBounds: { start: number, end: number} | null = null;
-                if (ranges && ranges.length > 0) {
-                  for (let i = 0; i < ranges.length; i += 2) {
-                    const startseg = ranges[i];
-                    const endseg = ranges[i + 1];
-                    if (frameRef.value >= startseg && frameRef.value <= endseg) {
-                      insideSegmentBounds = { start: startseg, end: endseg };
-                      break;
-                    }
-                  }
-                }
-                if (insideSegmentBounds) {
-                  updateAttribute({
-                    name: attribute.name,
-                    value: val,
-                    belongs: attribute.belongs,
-                    frame: insideSegmentBounds.start,
-                  });
-                  updateAttribute({
-                    name: attribute.name,
-                    value: val,
-                    belongs: attribute.belongs,
-                    frame: insideSegmentBounds.end,
-                  });
-                  updateButtonMap();
-                  return;
-                }
-              }
-              // Create attribute segment
-              const segmentCreationFrames = (track.end - track.begin) * trackPercentSize;
-              const start = Math.round(frame - (segmentCreationFrames / 2.0));
-              const end = Math.round(frame + (segmentCreationFrames / 2.0));
-              updateAttribute({
-                name: attribute.name,
-                value: val,
-                belongs: attribute.belongs,
-                frame: start,
-              });
-              updateAttribute({
-                name: attribute.name,
-                value: val,
-                belongs: attribute.belongs,
-                frame: end,
-              });
+              createSegmentHandler(shortcut, attribute, val);
               updateButtonMap();
               return;
             }
@@ -431,7 +463,7 @@ export default defineComponent({
       return { trackAttributes: {}, detectionAttributes: {} };
     });
 
-    const getAttributeValue = (key: string, type: Attribute['belongs'], userAttr: boolean) : string | number | boolean | unknown => {
+    const getAttributeValue = (key: string, type: Attribute['belongs'], userAttr: boolean): string | number | boolean | unknown => {
       const attributes = type === 'detection' ? selectedAttributes.value.detectionAttributes : selectedAttributes.value.trackAttributes;
       if (userAttr && attributes?.userAttributes) {
         const user = store.state.User.user?.login;
@@ -488,10 +520,10 @@ export default defineComponent({
     //   return buttonMapping;
     // });
 
-    const buttonValueMap: Ref<Record<string, {attribute: string, button: string; value: string | boolean | number | unknown; length: number }>> = ref({});
+    const buttonValueMap: Ref<Record<string, { attribute: string, button: string; value: string | boolean | number | unknown; length: number }>> = ref({});
 
     const updateButtonMap = () => {
-      const buttonMapping: Record<string, {attribute: string, button: string; value: string | boolean | number | unknown; length: number }> = {};
+      const buttonMapping: Record<string, { attribute: string, button: string; value: string | boolean | number | unknown; length: number }> = {};
       attributeButtons.value.forEach((attribute) => attribute.buttons.forEach((button) => {
         if (button.displayValue) {
           if (button.segment && selectedTrackIdRef.value !== null) {
@@ -566,19 +598,14 @@ export default defineComponent({
 </script>
 
 <template>
-  <StackedVirtualSidebarContainer
-    :width="updatedWidth"
-    :enable-slot="false"
-  >
+  <StackedVirtualSidebarContainer :width="updatedWidth" :enable-slot="false">
     <template #default>
       <v-container>
         <p v-for="(item, index) in information" :key="`information_${index}`">
           {{ item }}
         </p>
         <v-divider />
-        <v-row v-if="actionButtons.length" dense>
-          Action Buttons
-        </v-row>
+        <v-row v-if="actionButtons.length" dense> Action Buttons </v-row>
         <v-row v-if="actionButtons.length" class="my-1">
           <v-col v-for="(button, index) in actionButtons" :key="`action_${index}`">
             <v-tooltip bottom>
@@ -607,9 +634,7 @@ export default defineComponent({
         <p v-if="attributeButtons.length && selectedTrackIdRef === null">
           Attribute Action Buttons are disabled because no track is selected
         </p>
-        <p v-else>
-          Attribute Buttons
-        </p>
+        <p v-else>Attribute Buttons</p>
         <v-row v-for="(attribute, index) in attributeButtons" :key="`attribute_${index}`">
           <v-col cols="12">
             <v-row>

--- a/client/dive-common/components/CustomUI/CustomUIBase.vue
+++ b/client/dive-common/components/CustomUI/CustomUIBase.vue
@@ -605,7 +605,9 @@ export default defineComponent({
           {{ item }}
         </p>
         <v-divider />
-        <v-row v-if="actionButtons.length" dense> Action Buttons </v-row>
+        <v-row v-if="actionButtons.length" dense>
+          Action Buttons
+        </v-row>
         <v-row v-if="actionButtons.length" class="my-1">
           <v-col v-for="(button, index) in actionButtons" :key="`action_${index}`">
             <v-tooltip bottom>
@@ -634,7 +636,9 @@ export default defineComponent({
         <p v-if="attributeButtons.length && selectedTrackIdRef === null">
           Attribute Action Buttons are disabled because no track is selected
         </p>
-        <p v-else>Attribute Buttons</p>
+        <p v-else>
+          Attribute Buttons
+        </p>
         <v-row v-for="(attribute, index) in attributeButtons" :key="`attribute_${index}`">
           <v-col cols="12">
             <v-row>

--- a/client/dive-common/components/DatasetInfo.vue
+++ b/client/dive-common/components/DatasetInfo.vue
@@ -134,20 +134,28 @@ export default defineComponent({
           <v-expansion-panel v-if="processedDatasetMetadata" class="border">
             <v-expansion-panel-header>DIVE Metadata</v-expansion-panel-header>
             <v-expansion-panel-content class="pa-0">
-              <v-list-item two-line v-for="(value, name) in processedDatasetMetadata.default" :key="`datasetMetadata_${name}`" dense>
+              <v-list-item v-for="(value, name) in processedDatasetMetadata.default" :key="`datasetMetadata_${name}`" two-line dense>
                 <v-list-item-content>
-                  <v-list-item-title v-html="name" />
-                  <v-list-item-subtitle v-html="value !== undefined ? value.toString() : ''" class="wrap-text" />
+                  <v-list-item-title>
+                    {{ name }}
+                  </v-list-item-title>
+                  <v-list-item-subtitle class="wrap-text">
+                    {{ value !== undefined ? value.toString() : '' }}
+                  </v-list-item-subtitle>
                 </v-list-item-content>
               </v-list-item>
               <v-expansion-panels>
                 <v-expansion-panel>
                   <v-expansion-panel-header>Advanced</v-expansion-panel-header>
                   <v-expansion-panel-content class="pa-0">
-                    <v-list-item two-line v-for="(value, name) in processedDatasetMetadata.advanced" :key="`datasetMetadata_${name}`" dense>
+                    <v-list-item v-for="(value, name) in processedDatasetMetadata.advanced" :key="`datasetMetadata_${name}`" two-line dense>
                       <v-list-item-content>
-                        <v-list-item-title v-html="name" />
-                        <v-list-item-subtitle v-html="value !== undefined ? value.toString() : ''" class="wrap-text" />
+                        <v-list-item-title>
+                          {{ name }}
+                        </v-list-item-title>
+                        <v-list-item-subtitle class="wrap-text">
+                          {{ value !== undefined ? value.toString() : '' }}
+                        </v-list-item-subtitle>
                       </v-list-item-content>
                     </v-list-item>
                   </v-expansion-panel-content>

--- a/client/package.json
+++ b/client/package.json
@@ -168,7 +168,7 @@
       "vue/no-unused-components": "off",
       "vue/valid-v-slot": "off",
       "vuejs-accessibility/alt-text": "off",
-      "vue/no-v-text-v-html-on-component": "off",
+      "vue/no-v-text-v-html-on-component": "on",
       "@typescript-eslint/no-unused-vars": "off",
       "vue/no-template-target-blank": "off",
       "vue/no-lone-template": "off",

--- a/client/package.json
+++ b/client/package.json
@@ -168,6 +168,7 @@
       "vue/no-unused-components": "off",
       "vue/valid-v-slot": "off",
       "vuejs-accessibility/alt-text": "off",
+      "vue/no-v-text-v-html-on-component": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "vue/no-template-target-blank": "off",
       "vue/no-lone-template": "off",

--- a/client/package.json
+++ b/client/package.json
@@ -168,7 +168,6 @@
       "vue/no-unused-components": "off",
       "vue/valid-v-slot": "off",
       "vuejs-accessibility/alt-text": "off",
-      "vue/no-v-text-v-html-on-component": "on",
       "@typescript-eslint/no-unused-vars": "off",
       "vue/no-template-target-blank": "off",
       "vue/no-lone-template": "off",

--- a/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataSearch.vue
+++ b/client/platform/web-girder/views/DIVEMetadata/DIVEMetadataSearch.vue
@@ -261,8 +261,8 @@ export default defineComponent({
               <v-icon
                 small
                 class="ml-1"
-                @click.stop.prevent="openInNewTab(item.DIVEDataset)"
                 style="cursor:pointer;"
+                @click.stop.prevent="openInNewTab(item.DIVEDataset)"
               >
                 mdi-open-in-new
               </v-icon>

--- a/client/src/use/AttributeTypes.ts
+++ b/client/src/use/AttributeTypes.ts
@@ -68,6 +68,8 @@ export interface AttributeShortcut {
     // segment Means that the adding will add two points and that deletion will delete a segment when inside it
     segment?: boolean; // if this shortcut is for a segment
     segmentEditable?: boolean;
+    segmentSize?: number; // size of segment to add
+    segmentSizeType?: 'frames' | 'seconds' | 'percent';
     description?: string;
     button?: ButtonShortcut;
   }

--- a/server/dive_utils/models.py
+++ b/server/dive_utils/models.py
@@ -146,6 +146,8 @@ class ShortcutAttributeOptions(BaseModel):
     description: Optional[str]
     segment: Optional[bool]
     segmentEditable: Optional[bool]
+    segmentSize: Optional[float]
+    segmentSizeType: Optional[Literal['frames', 'seconds', 'percent']]
     type: Literal['set', 'dialog', 'remove']
     button: Optional[ButtonShortcut]
 


### PR DESCRIPTION
resolves #321 

- Creates new `segmentSize` and `segmentSizeType` when an attribute has segment selected
- Defaults to 'percent' and '0.01' for the values
- Has capabilities for 'percent' - size of overall track, 'seconds' - based on the video framerate, and 'frames'
- The value has to be btewee 0.001 and 1.0 for percentage but only needs to be 1 and in integer format for 'frames' and 'seconds'
- Refactored logic so that segments won't overwrite neighboring segments and will instead be a smaller size as needed by giving a small space between them.